### PR TITLE
Support api_apps/api_app_keys schema and update docs

### DIFF
--- a/config/app-context.php
+++ b/config/app-context.php
@@ -49,7 +49,14 @@ return [
 
         // Configuration for 'eloquent' driver (database required)
         'eloquent' => [
+            // Legacy single-table schema
             'table' => env('APP_CONTEXT_CLIENTS_TABLE', 'api_clients'),
+            // Multi-table schema (recommended)
+            'apps_table' => env('APP_CONTEXT_APPS_TABLE', 'api_apps'),
+            'app_keys_table' => env('APP_CONTEXT_APP_KEYS_TABLE', 'api_app_keys'),
+            // Optional: pass your Eloquent model classes (preferred for multi-table)
+            'app_model' => env('APP_CONTEXT_APP_MODEL'),
+            'app_key_model' => env('APP_CONTEXT_APP_KEY_MODEL'),
             'connection' => env('APP_CONTEXT_CLIENTS_CONNECTION', null),
             'hash_algorithm' => env('API_KEY_HASH_ALGO', 'argon2id'),
             'prefix_length' => 10,

--- a/src/Contracts/ClientRepositoryInterface.php
+++ b/src/Contracts/ClientRepositoryInterface.php
@@ -21,9 +21,10 @@ interface ClientRepositoryInterface
      * Find a client by its public identifier (app_code).
      *
      * @param string $appCode The unique client identifier
+     * @param string|null $keyPrefix Optional key prefix for multi-key storage
      * @return ClientInfo|null Client data or null if not found/inactive
      */
-    public function findByAppCode(string $appCode): ?ClientInfo;
+    public function findByAppCode(string $appCode, ?string $keyPrefix = null): ?ClientInfo;
 
     /**
      * Verify a key against stored hash.
@@ -42,8 +43,15 @@ interface ClientRepositoryInterface
      *
      * @param string $appCode The client identifier
      * @param string $ip The IP address of the request
+     * @param string|null $keyPrefix Optional key prefix for multi-key storage
+     * @param string|null $userAgent Optional user agent for audit trails
      */
-    public function trackUsage(string $appCode, string $ip): void;
+    public function trackUsage(
+        string $appCode,
+        string $ip,
+        ?string $keyPrefix = null,
+        ?string $userAgent = null
+    ): void;
 
     /**
      * Generate a new API key with hash.

--- a/src/Repositories/ConfigClientRepository.php
+++ b/src/Repositories/ConfigClientRepository.php
@@ -58,7 +58,7 @@ final class ConfigClientRepository implements ClientRepositoryInterface
     /**
      * {@inheritdoc}
      */
-    public function findByAppCode(string $appCode): ?ClientInfo
+    public function findByAppCode(string $appCode, ?string $keyPrefix = null): ?ClientInfo
     {
         if (!isset($this->clients[$appCode])) {
             return null;
@@ -95,7 +95,12 @@ final class ConfigClientRepository implements ClientRepositoryInterface
      *
      * No-op for config-based repository.
      */
-    public function trackUsage(string $appCode, string $ip): void
+    public function trackUsage(
+        string $appCode,
+        string $ip,
+        ?string $keyPrefix = null,
+        ?string $userAgent = null
+    ): void
     {
         // Config-based repository doesn't track usage
         // Override in custom implementation if needed

--- a/src/Repositories/EloquentClientRepository.php
+++ b/src/Repositories/EloquentClientRepository.php
@@ -7,9 +7,11 @@ namespace Ronu\AppContext\Repositories;
 use Ronu\AppContext\Contracts\ClientRepositoryInterface;
 use Ronu\AppContext\Support\ClientInfo;
 use DateTimeImmutable;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
+use RuntimeException;
 
 /**
  * Eloquent/Database-based client repository.
@@ -17,7 +19,7 @@ use Illuminate\Support\Str;
  * This implementation uses direct database queries (not a specific model),
  * allowing users to use any table structure that matches the expected schema.
  *
- * Required columns:
+ * Required columns (legacy single-table):
  * - app_code (string, unique)
  * - name (string)
  * - key_hash (string)
@@ -29,10 +31,14 @@ use Illuminate\Support\Str;
  * - is_revoked (boolean)
  * - expires_at (timestamp, nullable)
  *
- * Optional columns for tracking:
+ * Optional columns for tracking (legacy):
  * - last_used_at (timestamp)
  * - last_used_ip (string)
  * - usage_count (integer)
+ *
+ * Multi-table schema (recommended):
+ * - api_apps (clients)
+ * - api_app_keys (keys per app)
  *
  * @package Ronu\AppContext\Repositories
  */
@@ -47,6 +53,31 @@ final class EloquentClientRepository implements ClientRepositoryInterface
      * @var string|null Database connection name
      */
     private readonly ?string $connection;
+
+    /**
+     * @var string Database table name for apps
+     */
+    private readonly string $appsTable;
+
+    /**
+     * @var string Database table name for app keys
+     */
+    private readonly string $appKeysTable;
+
+    /**
+     * @var string|null Eloquent model class for apps
+     */
+    private readonly ?string $appModelClass;
+
+    /**
+     * @var string|null Eloquent model class for app keys
+     */
+    private readonly ?string $appKeyModelClass;
+
+    /**
+     * @var bool Whether to use the multi-table schema
+     */
+    private readonly bool $useSeparateKeysTable;
 
     /**
      * @var string Hash algorithm
@@ -73,19 +104,69 @@ final class EloquentClientRepository implements ClientRepositoryInterface
      */
     public function __construct(array $config)
     {
+        $this->appModelClass = $config['app_model'] ?? null;
+        $this->appKeyModelClass = $config['app_key_model'] ?? null;
         $this->table = $config['table'] ?? 'api_clients';
+        $this->appsTable = $config['apps_table'] ?? 'api_apps';
+        $this->appKeysTable = $config['app_keys_table'] ?? 'api_app_keys';
         $this->connection = $config['connection'] ?? null;
         $this->hashAlgorithm = $config['hash_algorithm'] ?? 'argon2id';
         $this->prefixLength = $config['prefix_length'] ?? 10;
         $this->keyLength = $config['key_length'] ?? 32;
         $this->asyncTracking = $config['async_tracking'] ?? true;
+        $this->useSeparateKeysTable = $this->appModelClass !== null
+            || $this->appKeyModelClass !== null
+            || isset($config['apps_table'])
+            || isset($config['app_keys_table']);
+
+        if ($this->appModelClass !== null) {
+            $appModel = $this->instantiateModel($this->appModelClass);
+            $this->appsTable = $appModel->getTable();
+            $this->connection ??= $appModel->getConnectionName();
+        }
+
+        if ($this->appKeyModelClass !== null) {
+            $keyModel = $this->instantiateModel($this->appKeyModelClass);
+            $this->appKeysTable = $keyModel->getTable();
+            $this->connection ??= $keyModel->getConnectionName();
+        }
     }
 
     /**
      * {@inheritdoc}
      */
-    public function findByAppCode(string $appCode): ?ClientInfo
+    public function findByAppCode(string $appCode, ?string $keyPrefix = null): ?ClientInfo
     {
+        if ($this->useSeparateKeysTable) {
+            $appRecord = $this->appQuery()
+                ->where('app_code', $appCode)
+                ->where('is_active', true)
+                ->whereNull('deleted_at')
+                ->first();
+
+            if ($appRecord === null) {
+                return null;
+            }
+
+            $keyQuery = $this->appKeyQuery()
+                ->where('app_id', $appRecord->id)
+                ->whereNull('revoked_at');
+
+            if ($keyPrefix !== null) {
+                $keyQuery->where('key_prefix', $keyPrefix);
+            }
+
+            $keyRecord = $keyQuery
+                ->orderBy('created_at', 'desc')
+                ->first();
+
+            if ($keyRecord === null) {
+                return null;
+            }
+
+            return $this->toClientInfo($appRecord, $keyRecord);
+        }
+
         $record = $this->query()
             ->where('app_code', $appCode)
             ->where('is_active', true)
@@ -114,9 +195,36 @@ final class EloquentClientRepository implements ClientRepositoryInterface
     /**
      * {@inheritdoc}
      */
-    public function trackUsage(string $appCode, string $ip): void
+    public function trackUsage(
+        string $appCode,
+        string $ip,
+        ?string $keyPrefix = null,
+        ?string $userAgent = null
+    ): void
     {
-        $updateFn = function () use ($appCode, $ip) {
+        $updateFn = function () use ($appCode, $ip, $keyPrefix, $userAgent) {
+            if ($this->useSeparateKeysTable) {
+                $appRecord = $this->appQuery()
+                    ->where('app_code', $appCode)
+                    ->whereNull('deleted_at')
+                    ->first();
+
+                if ($appRecord === null || $keyPrefix === null) {
+                    return;
+                }
+
+                $this->appKeyQuery()
+                    ->where('app_id', $appRecord->id)
+                    ->where('key_prefix', $keyPrefix)
+                    ->update([
+                        'last_used_at' => now(),
+                        'last_used_ip' => $ip,
+                        'last_user_agent' => $userAgent,
+                    ]);
+
+                return;
+            }
+
             $this->query()
                 ->where('app_code', $appCode)
                 ->update([
@@ -154,6 +262,10 @@ final class EloquentClientRepository implements ClientRepositoryInterface
      */
     public function create(array $data): ClientInfo
     {
+        if ($this->useSeparateKeysTable) {
+            return $this->createUsingSeparateTables($data);
+        }
+
         $keyData = $this->generateKey();
 
         $id = (string) Str::uuid();
@@ -213,6 +325,10 @@ final class EloquentClientRepository implements ClientRepositoryInterface
      */
     public function revoke(string $appCode): bool
     {
+        if ($this->useSeparateKeysTable) {
+            return $this->revokeUsingSeparateTables($appCode);
+        }
+
         $affected = $this->query()
             ->where('app_code', $appCode)
             ->update([
@@ -228,6 +344,12 @@ final class EloquentClientRepository implements ClientRepositoryInterface
      */
     public function all(array $filters = []): iterable
     {
+        if ($this->useSeparateKeysTable) {
+            yield from $this->allUsingSeparateTables($filters);
+
+            return;
+        }
+
         $query = $this->query()->whereNull('deleted_at');
 
         if (isset($filters['channel'])) {
@@ -258,6 +380,28 @@ final class EloquentClientRepository implements ClientRepositoryInterface
      */
     public function findByAppCodeIncludingInactive(string $appCode): ?ClientInfo
     {
+        if ($this->useSeparateKeysTable) {
+            $appRecord = $this->appQuery()
+                ->where('app_code', $appCode)
+                ->whereNull('deleted_at')
+                ->first();
+
+            if ($appRecord === null) {
+                return null;
+            }
+
+            $keyRecord = $this->appKeyQuery()
+                ->where('app_id', $appRecord->id)
+                ->orderBy('created_at', 'desc')
+                ->first();
+
+            if ($keyRecord === null) {
+                return null;
+            }
+
+            return $this->toClientInfo($appRecord, $keyRecord);
+        }
+
         $record = $this->query()
             ->where('app_code', $appCode)
             ->whereNull('deleted_at')
@@ -287,10 +431,46 @@ final class EloquentClientRepository implements ClientRepositoryInterface
     }
 
     /**
+     * Get the database query builder for apps.
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
+    private function appQuery()
+    {
+        $query = DB::table($this->appsTable);
+
+        if ($this->connection !== null) {
+            $query = DB::connection($this->connection)->table($this->appsTable);
+        }
+
+        return $query;
+    }
+
+    /**
+     * Get the database query builder for app keys.
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
+    private function appKeyQuery()
+    {
+        $query = DB::table($this->appKeysTable);
+
+        if ($this->connection !== null) {
+            $query = DB::connection($this->connection)->table($this->appKeysTable);
+        }
+
+        return $query;
+    }
+
+    /**
      * Convert database record to ClientInfo.
      */
-    private function toClientInfo(object $record): ClientInfo
+    private function toClientInfo(object $record, ?object $keyRecord = null): ClientInfo
     {
+        if ($this->useSeparateKeysTable && $keyRecord !== null) {
+            return $this->toClientInfoFromSeparateTables($record, $keyRecord);
+        }
+
         $config = is_string($record->config)
             ? json_decode($record->config, true)
             : (array) ($record->config ?? []);
@@ -328,6 +508,276 @@ final class EloquentClientRepository implements ClientRepositoryInterface
             id: $record->id ?? null,
             keyPrefix: $record->key_prefix ?? null,
         );
+    }
+
+    /**
+     * Convert separate app + key records to ClientInfo.
+     */
+    private function toClientInfoFromSeparateTables(object $appRecord, object $keyRecord): ClientInfo
+    {
+        $appConfig = is_string($appRecord->config)
+            ? json_decode($appRecord->config, true)
+            : (array) ($appRecord->config ?? []);
+
+        $appMetadata = is_string($appRecord->metadata ?? null)
+            ? json_decode($appRecord->metadata, true)
+            : (array) ($appRecord->metadata ?? []);
+
+        $keyConfig = is_string($keyRecord->config)
+            ? json_decode($keyRecord->config, true)
+            : (array) ($keyRecord->config ?? []);
+
+        $expiresAt = null;
+        if (isset($keyRecord->expires_at) && $keyRecord->expires_at !== null) {
+            $expiresAt = $keyRecord->expires_at instanceof \DateTimeInterface
+                ? $keyRecord->expires_at
+                : new DateTimeImmutable($keyRecord->expires_at);
+        }
+
+        $capabilities = $keyConfig['capabilities'] ?? $this->parseScopes($keyRecord->scopes ?? null);
+        $ipAllowlist = $keyConfig['ip_allowlist'] ?? $appConfig['ip_allowlist'] ?? [];
+
+        return new ClientInfo(
+            appCode: $appRecord->app_code,
+            name: $appRecord->app_name ?? $appRecord->app_code,
+            keyHash: $keyRecord->key_hash,
+            channel: $appConfig['channel'] ?? 'partner',
+            tenantId: $appConfig['tenant_id'] ?? null,
+            capabilities: $capabilities,
+            ipAllowlist: $ipAllowlist,
+            isActive: (bool) $appRecord->is_active,
+            isRevoked: $keyRecord->revoked_at !== null,
+            expiresAt: $expiresAt,
+            metadata: [
+                ...$appMetadata,
+                'rate_limit_tier' => $keyConfig['rate_limit_tier'] ?? $appConfig['rate_limit_tier'] ?? 'default',
+                'webhook_url' => $keyConfig['webhook_url'] ?? $appConfig['webhook_url'] ?? null,
+                'last_used_at' => $keyRecord->last_used_at ?? null,
+                'last_used_ip' => $keyRecord->last_used_ip ?? null,
+                'last_user_agent' => $keyRecord->last_user_agent ?? null,
+                'created_at' => $appRecord->created_at ?? null,
+            ],
+            id: (string) ($appRecord->id ?? ''),
+            keyPrefix: $keyRecord->key_prefix ?? null,
+        );
+    }
+
+    /**
+     * Create a client using the separate apps/keys tables.
+     *
+     * @param array<string, mixed> $data
+     */
+    private function createUsingSeparateTables(array $data): ClientInfo
+    {
+        $keyData = $this->generateKey();
+        $now = now();
+
+        $appCode = $data['app_code'] ?? Str::slug($data['name']) . '_' . Str::random(8);
+        $appConfig = [
+            'channel' => $data['channel'] ?? 'partner',
+            'tenant_id' => $data['tenant_id'] ?? null,
+            'rate_limit_tier' => $data['rate_limit_tier'] ?? 'default',
+            'webhook_url' => $data['webhook_url'] ?? null,
+            'ip_allowlist' => $data['ip_allowlist'] ?? [],
+        ];
+
+        $appRecord = [
+            'app_code' => $appCode,
+            'app_name' => $data['name'],
+            'description' => $data['description'] ?? null,
+            'owner_email' => $data['owner_email'] ?? null,
+            'is_active' => $data['is_active'] ?? true,
+            'config' => json_encode($appConfig),
+            'metadata' => isset($data['metadata']) ? json_encode($data['metadata']) : null,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ];
+
+        $appId = $this->appQuery()->insertGetId($appRecord);
+
+        $capabilities = $data['capabilities'] ?? ['partner:*'];
+
+        $keyRecord = [
+            'app_id' => $appId,
+            'label' => $data['key_label'] ?? 'default',
+            'key_prefix' => $keyData['prefix'],
+            'key_hash' => $keyData['hash'],
+            'key_ciphertext' => $data['key_ciphertext'] ?? null,
+            'phrase' => $data['phrase'] ?? null,
+            'scopes' => $this->serializeScopes($capabilities),
+            'config' => json_encode([
+                'capabilities' => $capabilities,
+                'rate_limit_tier' => $data['rate_limit_tier'] ?? 'default',
+                'webhook_url' => $data['webhook_url'] ?? null,
+                'ip_allowlist' => $data['ip_allowlist'] ?? [],
+            ]),
+            'expires_at' => $data['expires_at'] ?? null,
+            'revoked_at' => null,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ];
+
+        $keyId = $this->appKeyQuery()->insertGetId($keyRecord);
+
+        $clientInfo = $this->toClientInfo(
+            (object) [...$appRecord, 'id' => $appId],
+            (object) [...$keyRecord, 'id' => $keyId]
+        );
+
+        return new ClientInfo(
+            appCode: $clientInfo->appCode,
+            name: $clientInfo->name,
+            keyHash: $clientInfo->keyHash,
+            channel: $clientInfo->channel,
+            tenantId: $clientInfo->tenantId,
+            capabilities: $clientInfo->capabilities,
+            ipAllowlist: $clientInfo->ipAllowlist,
+            isActive: $clientInfo->isActive,
+            isRevoked: $clientInfo->isRevoked,
+            expiresAt: $clientInfo->expiresAt,
+            metadata: [
+                ...$clientInfo->metadata,
+                'generated_key' => $keyData['key'],
+            ],
+            id: $clientInfo->id,
+            keyPrefix: $clientInfo->keyPrefix,
+        );
+    }
+
+    /**
+     * Revoke a client and all keys in the separate tables schema.
+     */
+    private function revokeUsingSeparateTables(string $appCode): bool
+    {
+        $appRecord = $this->appQuery()
+            ->where('app_code', $appCode)
+            ->whereNull('deleted_at')
+            ->first();
+
+        if ($appRecord === null) {
+            return false;
+        }
+
+        $this->appQuery()
+            ->where('id', $appRecord->id)
+            ->update([
+                'is_active' => false,
+                'updated_at' => now(),
+            ]);
+
+        $affected = $this->appKeyQuery()
+            ->where('app_id', $appRecord->id)
+            ->whereNull('revoked_at')
+            ->update([
+                'revoked_at' => now(),
+                'updated_at' => now(),
+            ]);
+
+        return $affected > 0;
+    }
+
+    /**
+     * List all clients using separate tables.
+     *
+     * @param array<string, mixed> $filters
+     * @return iterable<ClientInfo>
+     */
+    private function allUsingSeparateTables(array $filters = []): iterable
+    {
+        $query = $this->appQuery()->whereNull('deleted_at');
+
+        if (!($filters['include_inactive'] ?? false)) {
+            $query->where('is_active', true);
+        }
+
+        $query->orderBy('created_at', 'desc');
+
+        foreach ($query->cursor() as $appRecord) {
+            $keyQuery = $this->appKeyQuery()
+                ->where('app_id', $appRecord->id);
+
+            if (!($filters['include_revoked'] ?? false)) {
+                $keyQuery->whereNull('revoked_at');
+            }
+
+            $keyRecord = $keyQuery->orderBy('created_at', 'desc')->first();
+
+            if ($keyRecord === null) {
+                continue;
+            }
+
+            $client = $this->toClientInfo($appRecord, $keyRecord);
+
+            if (isset($filters['channel']) && $client->channel !== $filters['channel']) {
+                continue;
+            }
+
+            if (isset($filters['tenant']) && $client->tenantId !== $filters['tenant']) {
+                continue;
+            }
+
+            yield $client;
+        }
+    }
+
+    /**
+     * Instantiate an Eloquent model from a class name.
+     *
+     * @throws RuntimeException
+     */
+    private function instantiateModel(string $modelClass): Model
+    {
+        if (!class_exists($modelClass)) {
+            throw new RuntimeException("Model class '{$modelClass}' does not exist.");
+        }
+
+        $model = new $modelClass();
+
+        if (!$model instanceof Model) {
+            throw new RuntimeException("Model class '{$modelClass}' must extend " . Model::class);
+        }
+
+        return $model;
+    }
+
+    /**
+     * Parse scopes from the api_app_keys.scopes field.
+     *
+     * @return array<string>
+     */
+    private function parseScopes(array|string|null $scopes): array
+    {
+        if (is_array($scopes)) {
+            return $scopes;
+        }
+
+        if ($scopes === null) {
+            return [];
+        }
+
+        if (is_string($scopes)) {
+            $decoded = json_decode($scopes, true);
+            if (is_array($decoded)) {
+                return $decoded;
+            }
+
+            return array_values(array_filter(
+                preg_split('/[\s,]+/', $scopes) ?: [],
+                static fn(string $value): bool => $value !== ''
+            ));
+        }
+
+        return [];
+    }
+
+    /**
+     * Serialize scopes for storage in api_app_keys.scopes.
+     *
+     * @param array<string> $scopes
+     */
+    private function serializeScopes(array $scopes): string
+    {
+        return implode(' ', $scopes);
     }
 
     /**


### PR DESCRIPTION
### Motivation

- Add support for a multi-table API client schema (`api_apps` / `api_app_keys`) so a single app can own multiple keys and key-level metadata is tracked separately.
- Allow the repository and verifier to use the key prefix to find and update the correct key record when multiple keys exist per app.
- Update configuration and documentation so integrators can opt into the new schema, pass Eloquent model classes, and understand middleware/login integration.

### Description

- Extend `ClientRepositoryInterface` to accept an optional `keyPrefix` in `findByAppCode` and to accept `keyPrefix` and `userAgent` in `trackUsage` so implementations can target per-key records.
- Update `ApiKeyVerifier` to extract the key prefix from `X-Api-Key` and pass it to the repository, and to pass `userAgent` when tracking usage.
- Enhance `EloquentClientRepository` to support both legacy single-table (`api_clients`) and recommended multi-table schemas (`api_apps` + `api_app_keys`), detect optional model classes, query/create/revoke keys in the separate table flow, and track per-key usage (`last_used_*`) and scopes handling (`scopes` parsing/serialization).
- Update `ConfigClientRepository` and docs/examples to accept the new method signatures and configuration options.
- Add configuration keys to `config/app-context.php` and environment variables examples for `apps_table`, `app_keys_table`, `app_model` and `app_key_model`.
- Expand `README.md` and `README.es.md` with a `Middleware Integration Guide`, explicit `api_apps`/`api_app_keys` login flow, migration guidance, and updated examples for custom repositories.

Files changed (key): `src/Contracts/ClientRepositoryInterface.php`, `src/Auth/Verifiers/ApiKeyVerifier.php`, `src/Repositories/EloquentClientRepository.php`, `src/Repositories/ConfigClientRepository.php`, `config/app-context.php`, `README.md`, `README.es.md`.

### Testing

- No automated tests were executed as part of this change (no `phpunit`/`composer test` run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697231c3430c832ca6846d2ffee6444c)