### PR TITLE
Allow JWT issuer URLs with additional paths

### DIFF
--- a/src/Auth/Verifiers/JwtVerifier.php
+++ b/src/Auth/Verifiers/JwtVerifier.php
@@ -279,7 +279,7 @@ final class JwtVerifier implements VerifierInterface
         // Verify issuer
         if ($this->verifyIssuer && $this->expectedIssuer !== null) {
             $issuer = $claims['iss'] ?? null;
-            if ($issuer !== $this->expectedIssuer) {
+            if (! $this->issuerMatches($issuer)) {
                 throw AuthenticationException::invalidToken(
                     "Invalid issuer. Expected '{$this->expectedIssuer}', got '{$issuer}'"
                 );
@@ -298,5 +298,27 @@ final class JwtVerifier implements VerifierInterface
     public function getJwtAuth(): JWTAuth
     {
         return $this->jwtAuth;
+    }
+
+    private function issuerMatches(?string $issuer): bool
+    {
+        if ($issuer === null) {
+            return false;
+        }
+
+        $expected = rtrim((string) $this->expectedIssuer, '/');
+        $actual = rtrim($issuer, '/');
+
+        if ($actual === $expected) {
+            return true;
+        }
+
+        if (! str_starts_with($actual, $expected)) {
+            return false;
+        }
+
+        $nextChar = substr($actual, strlen($expected), 1);
+
+        return $nextChar === '' || $nextChar === '/' || $nextChar === '?' || $nextChar === '#';
     }
 }


### PR DESCRIPTION
### Motivation
- JWT issuer validation rejected tokens whose `iss` extended the configured base URL (for example tokens issued at `http://localhost/tencent/public/api/login` when expected was `http://localhost/tencent`), causing valid tokens to fail verification; the change relaxes matching while preserving boundary safety.

### Description
- Replace the strict equality check for issuer with a new `issuerMatches` helper that trims trailing slashes and accepts either an exact match or the expected issuer as a prefix only when followed by a safe delimiter.
- Update `postVerify` in `JwtVerifier` to call `issuerMatches(?string $issuer): bool` instead of direct `===` comparison, preventing accidental prefix collisions while allowing legitimate extended issuer URLs.
- No other logic or configuration values were changed.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69735b004290832c9b6b34fb5745f6ca)