### PR TITLE
Accept array audiences and relax issuer matching in JWT verifier

### DIFF
--- a/src/Auth/Verifiers/JwtVerifier.php
+++ b/src/Auth/Verifiers/JwtVerifier.php
@@ -279,7 +279,7 @@ final class JwtVerifier implements VerifierInterface
         // Verify issuer
         if ($this->verifyIssuer && $this->expectedIssuer !== null) {
             $issuer = $claims['iss'] ?? null;
-            if ($issuer !== $this->expectedIssuer) {
+            if (! $this->issuerMatches($issuer)) {
                 throw AuthenticationException::invalidToken(
                     "Invalid issuer. Expected '{$this->expectedIssuer}', got '{$issuer}'"
                 );
@@ -298,5 +298,27 @@ final class JwtVerifier implements VerifierInterface
     public function getJwtAuth(): JWTAuth
     {
         return $this->jwtAuth;
+    }
+
+    private function issuerMatches(?string $issuer): bool
+    {
+        if ($issuer === null) {
+            return false;
+        }
+
+        $expected = rtrim((string) $this->expectedIssuer, '/');
+        $actual = rtrim($issuer, '/');
+
+        if ($actual === $expected) {
+            return true;
+        }
+
+        if (! str_starts_with($actual, $expected)) {
+            return false;
+        }
+
+        $nextChar = substr($actual, strlen($expected), 1);
+
+        return $nextChar === '' || $nextChar === '/' || $nextChar === '?' || $nextChar === '#';
     }
 }

--- a/src/Exceptions/ContextBindingException.php
+++ b/src/Exceptions/ContextBindingException.php
@@ -12,10 +12,12 @@ class ContextBindingException extends AppContextException
     protected string $errorCode = 'CONTEXT_BINDING_FAILED';
     protected int $httpStatus = 403;
 
-    public static function audienceMismatch(string $expected, string $actual): self
+    public static function audienceMismatch(string $expected, string|array $actual): self
     {
+        $actualValue = is_array($actual) ? implode(', ', $actual) : $actual;
+
         return new self(
-            "Token audience mismatch. Expected '{$expected}', got '{$actual}'",
+            "Token audience mismatch. Expected '{$expected}', got '{$actualValue}'",
             'audience_binding'
         );
     }


### PR DESCRIPTION
### Motivation
- Tokens with an `aud` claim as an array caused type errors when building binding error messages and made audience mismatch diagnostics unreadable. 
- Issuer validation was too strict for tokens whose `iss` extended the configured base URL with additional path/query fragments, causing valid tokens to be rejected.

### Description
- Update `ContextBindingException::audienceMismatch` to accept `string|array` for the actual audience and normalize arrays into a readable comma-separated string for the exception message (`src/Exceptions/ContextBindingException.php`).
- Add `issuerMatches(?string $issuer): bool` to `JwtVerifier` and replace the strict `===` issuer comparison in `postVerify` with this helper to allow the expected issuer as a prefix only when followed by a safe delimiter (`/`, `?`, `#`) or nothing (`src/Auth/Verifiers/JwtVerifier.php`).
- Preserve existing behavior for blacklist, subject, and audience existence checks while avoiding accidental prefix collisions for issuer matching.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69735b004290832c9b6b34fb5745f6ca)