### PR TITLE
Support array JWT audiences in binding checks and relax issuer matching

### DIFF
--- a/src/Auth/Verifiers/JwtVerifier.php
+++ b/src/Auth/Verifiers/JwtVerifier.php
@@ -279,7 +279,7 @@ final class JwtVerifier implements VerifierInterface
         // Verify issuer
         if ($this->verifyIssuer && $this->expectedIssuer !== null) {
             $issuer = $claims['iss'] ?? null;
-            if ($issuer !== $this->expectedIssuer) {
+            if (! $this->issuerMatches($issuer)) {
                 throw AuthenticationException::invalidToken(
                     "Invalid issuer. Expected '{$this->expectedIssuer}', got '{$issuer}'"
                 );
@@ -298,5 +298,27 @@ final class JwtVerifier implements VerifierInterface
     public function getJwtAuth(): JWTAuth
     {
         return $this->jwtAuth;
+    }
+
+    private function issuerMatches(?string $issuer): bool
+    {
+        if ($issuer === null) {
+            return false;
+        }
+
+        $expected = rtrim((string) $this->expectedIssuer, '/');
+        $actual = rtrim($issuer, '/');
+
+        if ($actual === $expected) {
+            return true;
+        }
+
+        if (! str_starts_with($actual, $expected)) {
+            return false;
+        }
+
+        $nextChar = substr($actual, strlen($expected), 1);
+
+        return $nextChar === '' || $nextChar === '/' || $nextChar === '?' || $nextChar === '#';
     }
 }

--- a/src/Exceptions/ContextBindingException.php
+++ b/src/Exceptions/ContextBindingException.php
@@ -12,10 +12,12 @@ class ContextBindingException extends AppContextException
     protected string $errorCode = 'CONTEXT_BINDING_FAILED';
     protected int $httpStatus = 403;
 
-    public static function audienceMismatch(string $expected, string $actual): self
+    public static function audienceMismatch(string $expected, string|array $actual): self
     {
+        $actualValue = is_array($actual) ? implode(', ', $actual) : $actual;
+
         return new self(
-            "Token audience mismatch. Expected '{$expected}', got '{$actual}'",
+            "Token audience mismatch. Expected '{$expected}', got '{$actualValue}'",
             'audience_binding'
         );
     }

--- a/src/Middleware/EnforceContextBinding.php
+++ b/src/Middleware/EnforceContextBinding.php
@@ -65,7 +65,7 @@ class EnforceContextBinding
         if ($this->enforceAudience) {
             $tokenAudience = $context->getMetadataValue('audience');
 
-            if ($tokenAudience !== null && $tokenAudience !== $context->getAppId()) {
+            if ($tokenAudience !== null && ! $this->audienceMatches($tokenAudience, $context->getAppId())) {
                 throw ContextBindingException::audienceMismatch(
                     expected: $context->getAppId(),
                     actual: $tokenAudience
@@ -148,5 +148,17 @@ class EnforceContextBinding
         }
 
         return null;
+    }
+
+    /**
+     * Determine if token audience matches the expected channel.
+     */
+    protected function audienceMatches(string|array $tokenAudience, string $expected): bool
+    {
+        if (is_array($tokenAudience)) {
+            return in_array($expected, $tokenAudience, true);
+        }
+
+        return $tokenAudience === $expected;
     }
 }


### PR DESCRIPTION
### Motivation
- Tokens with an `aud` claim as an array produced poor error messages and caused binding checks to reject valid tokens.  
- Issuer validation was too strict for tokens whose `iss` extended the configured base URL with extra path/query fragments, causing valid tokens to be rejected.

### Description
- Change `ContextBindingException::audienceMismatch` to accept `string|array` for the actual audience and normalize arrays into a readable string for the error message.  
- Add `issuerMatches(?string $issuer): bool` to `JwtVerifier` and replace strict `===` comparison in `postVerify` with this helper so the configured issuer may be a prefix only when followed by a safe delimiter (`/`, `?`, `#`) or nothing.  
- Update `EnforceContextBinding` to accept array audiences by adding `audienceMatches(string|array $tokenAudience, string $expected): bool` and use it when enforcing audience binding.  
- Preserve existing blacklist, subject, and audience-existence checks and avoid accidental prefix collisions for issuer matching.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69735b004290832c9b6b34fb5745f6ca)