### PR TITLE
Add option to ignore scheme when validating JWT issuer claim

### DIFF
--- a/config/app-context.php
+++ b/config/app-context.php
@@ -400,6 +400,11 @@ return [
         // Verify issuer claim
         'verify_iss' => env('JWT_VERIFY_ISS', true),
 
+        // Ignore protocol (scheme) when validating issuer
+        // Useful for reverse proxy scenarios where protocol may change (http/https)
+        // When enabled, only the host and path are compared, ignoring the scheme
+        'ignore_issuer_scheme' => env('JWT_IGNORE_ISSUER_SCHEME', false),
+
         // Verify audience claim
         'verify_aud' => env('JWT_VERIFY_AUD', true),
 


### PR DESCRIPTION
## Summary
This PR adds support for ignoring the URL scheme (protocol) when validating JWT issuer claims. This is useful in reverse proxy scenarios where the protocol may differ between the client and server (e.g., HTTPS externally but HTTP internally).

## Changes
- Added `ignore_issuer_scheme` configuration option (defaults to `false`) in `config/app-context.php`
- Added `ignoreIssuerScheme` property to `JwtVerifier` class to store the configuration setting
- Implemented `stripScheme()` helper method to remove `http://` or `https://` prefixes from URLs
- Updated `issuerMatches()` method to optionally strip schemes before comparison when the feature is enabled

## Implementation Details
- The feature is disabled by default to maintain backward compatibility
- When enabled, only the host and path portions of the issuer URL are compared, ignoring whether the scheme is `http` or `https`
- The `stripScheme()` method uses case-insensitive regex matching to handle both uppercase and lowercase protocol prefixes
- Trailing slashes are still normalized before scheme comparison, maintaining existing behavior

https://claude.ai/code/session_0188eFToK6Bj76WtNVLm3dhj