### PR TITLE
Add comprehensive, modular documentation for ronu/laravel-app-context

### DIFF
--- a/documentation/ronu/laravel-app-context/README.md
+++ b/documentation/ronu/laravel-app-context/README.md
@@ -1,0 +1,110 @@
+# Laravel App Context (ronu/laravel-app-context)
+
+## ¿Qué es y qué resuelve?
+Laravel App Context es un paquete que resuelve **contexto de aplicación por canal** (mobile, admin, site, partner) y centraliza autenticación (JWT o API Key), autorización (scopes/capabilities), rate limiting por contexto y auditoría de solicitudes. Todo gira alrededor de un objeto inmutable `AppContext` que se inyecta en el request y en el contenedor para que el resto de la app pueda tomar decisiones consistentes por canal, tenant y credencial. 
+
+## Quickstart (mínimo viable)
+> Objetivo: canal `mobile` con JWT y middleware completo.
+
+1) Instala el paquete:
+```bash
+composer require ronu/laravel-app-context
+```
+
+2) Publica la configuración:
+```bash
+php artisan vendor:publish --tag=app-context-config
+```
+
+3) Define un canal (ejemplo `mobile`) en `config/app-context.php`:
+```php
+'channels' => [
+    'mobile' => [
+        'subdomains' => ['mobile', 'm'],
+        'path_prefixes' => ['/mobile'],
+        'auth_mode' => 'jwt',
+        'jwt_audience' => 'mobile',
+        'allowed_scopes' => ['mobile:*', 'user:profile:*'],
+        'rate_limit_profile' => 'mobile',
+        'tenant_mode' => 'multi',
+    ],
+],
+```
+
+4) Crea rutas con el middleware group `app-context`:
+```php
+// routes/api.php
+Route::prefix('mobile')
+    ->middleware(['app-context'])
+    ->group(function () {
+        Route::get('/profile', [UserController::class, 'profile'])
+            ->middleware('app.requires:user:profile:read');
+    });
+```
+
+5) En tu login, emite JWT con `aud` y `scp` coherentes con el canal:
+```php
+use PHPOpenSourceSaver\JWTAuth\Facades\JWTAuth;
+use Ronu\AppContext\Context\AppContext;
+
+public function login(Request $request, AppContext $context)
+{
+    // ... validar credenciales ...
+    $claims = [
+        'aud' => $context->getAppId(),
+        'tid' => $request->header('X-Tenant-Id'),
+        'scp' => ['mobile:*', 'user:profile:read'],
+    ];
+
+    $token = JWTAuth::claims($claims)->fromUser(Auth::user());
+
+    return response()->json([
+        'access_token' => $token,
+        'token_type' => 'Bearer',
+        'expires_in' => config('app-context.jwt.ttl'),
+    ]);
+}
+```
+
+6) Asegura que `app.binding` corre después de auth (en group o manual).
+
+## Índice
+- [Instalación](docs/01-installation.md)
+- [Configuración](docs/02-configuration.md)
+- [Arquitectura](docs/03-architecture.md)
+- [Features](docs/04-features/)
+- [Seguridad](docs/05-security.md)
+- [Testing](docs/06-testing.md)
+- [Troubleshooting](docs/07-troubleshooting.md)
+- [FAQ](docs/08-faq.md)
+- [Reference](docs/09-reference/)
+- [Migration guide](docs/10-migration-guide.md)
+- [Contributing](docs/11-contributing.md)
+- [License](docs/12-license.md)
+
+## Requisitos
+- PHP ^8.2
+- Laravel 11 o 12 (paquetes Illuminate)
+- `php-open-source-saver/jwt-auth` ^2.0
+
+## Common integration paths
+- **API multi-canal**: usa `app-context` group en rutas `/admin`, `/mobile`, `/partner` y define canales por `path_prefixes` o `subdomains`.
+- **B2B partners**: usa `auth_mode=api_key` con headers `X-Client-Id` y `X-Api-Key`.
+- **Public web + opcional JWT**: usa `auth_mode=jwt_or_anonymous` para permitir navegación pública y personalización si hay token.
+
+## Evidence
+- File: composer.json
+  - Symbol: name, require
+  - Notes: nombre del paquete y versiones mínimas de PHP/Laravel/JWT.
+- File: src/AppContextServiceProvider.php
+  - Symbol: AppContextServiceProvider::register(), AppContextServiceProvider::boot()
+  - Notes: auto-registro de middleware, provider y comandos.
+- File: config/app-context.php
+  - Symbol: channels, jwt, api_key, rate_limits
+  - Notes: configuración principal del paquete.
+- File: src/Middleware/AuthenticateChannel.php
+  - Symbol: AuthenticateChannel::handle()
+  - Notes: autenticación por canal.
+- File: src/Middleware/EnforceContextBinding.php
+  - Symbol: EnforceContextBinding::handle()
+  - Notes: binding de audience/tenant.

--- a/documentation/ronu/laravel-app-context/docs/01-installation.md
+++ b/documentation/ronu/laravel-app-context/docs/01-installation.md
@@ -1,0 +1,35 @@
+# Installation
+
+## 1) Instalar vía Composer
+```bash
+composer require ronu/laravel-app-context
+```
+
+## 2) Publicar configuración
+```bash
+php artisan vendor:publish --tag=app-context-config
+```
+Esto crea `config/app-context.php` con los defaults del paquete.
+
+## 3) Auto-discovery del Service Provider
+El provider se registra automáticamente por `extra.laravel.providers`. Si tu proyecto desactiva auto-discovery, agrega manualmente:
+```php
+// config/app.php
+'providers' => [
+    Ronu\AppContext\AppContextServiceProvider::class,
+],
+```
+
+## 4) (Opcional) Guard `app-context`
+El package registra un guard personalizado llamado `app-context`. Úsalo si necesitas integrarlo con el sistema de guards de Laravel.
+
+## Evidence
+- File: composer.json
+  - Symbol: extra.laravel.providers
+  - Notes: auto-discovery del provider.
+- File: src/AppContextServiceProvider.php
+  - Symbol: AppContextServiceProvider::boot(), AppContextServiceProvider::registerAuthGuard()
+  - Notes: publicación de config y registro del guard.
+- File: config/app-context.php
+  - Symbol: (archivo completo)
+  - Notes: config publicada por el tag `app-context-config`.

--- a/documentation/ronu/laravel-app-context/docs/02-configuration.md
+++ b/documentation/ronu/laravel-app-context/docs/02-configuration.md
@@ -1,0 +1,85 @@
+# Configuration
+
+El archivo `config/app-context.php` controla toda la operación del paquete: canales, autenticación, rate limiting, seguridad, logging y repositorios de clientes.
+
+## 1) Configuración base
+| Key | Descripción | Default/Example |
+| --- | --- | --- |
+| `deny_by_default` | Bloquea requests sin canal reconocido | `true` |
+| `default_channel` | Canal default si `deny_by_default=false` | `default` |
+| `domain` | Dominio base para extraer subdominio | `APP_CONTEXT_DOMAIN` |
+| `detection_strategy` | `auto`, `path`, `subdomain`, `strict` | `auto` |
+| `auto_detection_rules` | Reglas host → estrategia | ver archivo |
+| `app_context_dev` | entornos dev para `auto` | `local` |
+
+## 2) Canales
+Cada entrada en `channels` define detección, auth y permisos:
+
+```php
+'channels' => [
+    'admin' => [
+        'subdomains' => ['admin', 'dashboard'],
+        'path_prefixes' => ['/api'],
+        'auth_mode' => 'jwt',
+        'jwt_audience' => 'admin',
+        'allowed_scopes' => ['admin:*'],
+        'rate_limit_profile' => 'admin',
+        'tenant_mode' => 'multi',
+        'features' => ['mfa_required' => false],
+        'audit' => ['enabled' => true],
+    ],
+],
+```
+
+## 3) Client repository
+| Key | Descripción |
+| --- | --- |
+| `client_repository.driver` | `config`, `eloquent` o clase custom |
+| `client_repository.config` | Clientes definidos en config |
+| `client_repository.eloquent` | Tablas/modelos para DB |
+
+El repo se resuelve en tiempo de ejecución y debe implementar `ClientRepositoryInterface`.
+
+## 4) JWT
+| Key | Descripción |
+| --- | --- |
+| `jwt.algorithm` | `HS256`/`RS256` (RS recomendado en prod) |
+| `jwt.public_key_path`, `jwt.private_key_path` | rutas RSA |
+| `jwt.issuer`, `jwt.verify_iss` | validación de issuer |
+| `jwt.verify_aud` | valida `aud` |
+| `jwt.allowed_algorithms` | whitelist de algoritmos |
+| `jwt.token_sources` | `header`, `query`, `cookie` |
+| `jwt.dev_fallback` | fallback HS256 para dev |
+
+## 5) API Key
+| Key | Descripción |
+| --- | --- |
+| `api_key.hash_algorithm` | `argon2id` recomendado |
+| `api_key.headers.client_id` | default `X-Client-Id` |
+| `api_key.headers.api_key` | default `X-Api-Key` |
+| `api_key.rotation_days` | política de rotación |
+
+## 6) Rate limiting
+Se define por perfil (`rate_limits.<profile>`), con:
+- `global`, `authenticated_global`
+- `by` (`user`, `client_id`, `ip`, `user_device`, `ip_or_user`)
+- `burst`
+- `endpoints` con patrón `METHOD:/path`
+
+## 7) Security & audit
+- `security.strict_algorithm_check`, `security.enforce_tenant_binding`, `security.enforce_ip_allowlist`
+- `audit.enabled`, `audit.log_all_requests`, `audit.sensitive_headers`
+
+## 8) Public routes
+`public_routes` permite saltar autenticación en rutas públicas por:
+- `names`
+- `name_endings`
+- `path_endings`
+
+## Evidence
+- File: config/app-context.php
+  - Symbol: deny_by_default, default_channel, domain, detection_strategy, channels, client_repository, jwt, api_key, rate_limits, security, audit, public_routes
+  - Notes: configuración completa y defaults.
+- File: src/AppContextServiceProvider.php
+  - Symbol: AppContextServiceProvider::registerClientRepository()
+  - Notes: selección dinámica del repositorio de clientes.

--- a/documentation/ronu/laravel-app-context/docs/03-architecture.md
+++ b/documentation/ronu/laravel-app-context/docs/03-architecture.md
@@ -1,0 +1,61 @@
+# Architecture
+
+## Visión general
+La arquitectura se organiza en capas: **resolución de contexto**, **autenticación**, **binding**, **autorización**, **rate limiting** y **audit logging**. El pipeline de middleware asegura el orden correcto para construir y enriquecer el `AppContext`.
+
+## Componentes principales
+- **ContextResolver**: resuelve canal desde host/path.
+- **AppContext**: value object inmutable con identidad + permisos.
+- **Authenticators**: JWT, API Key, Anonymous.
+- **Verifiers**: validación de JWT y API Key.
+- **Repositories**: config o DB (Eloquent).
+- **Middleware**: orquesta el pipeline y aplica binding/rate limit/audit.
+
+## Diagrama textual del pipeline
+```
+Incoming Request
+  -> ResolveAppContext (host/path)
+  -> RateLimitByContext
+  -> AuthenticateChannel (jwt/api_key/anonymous)
+  -> EnforceContextBinding (aud + tenant)
+  -> RequireAbility (per-route)
+  -> InjectAuditContext
+  -> Controller
+```
+
+## Diagrama (Mermaid)
+```mermaid
+flowchart TD
+    A[Incoming Request] --> B[ResolveAppContext]
+    B --> C[RateLimitByContext]
+    C --> D{Auth Mode}
+    D -->|jwt| E[JwtAuthenticator]
+    D -->|api_key| F[ApiKeyAuthenticator]
+    D -->|anonymous| G[AnonymousAuthenticator]
+    E --> H[EnforceContextBinding]
+    F --> H
+    G --> H
+    H --> I[RequireAbility / RequireAllAbilities]
+    I --> J[InjectAuditContext]
+    J --> K[Controller]
+```
+
+## Evidence
+- File: src/AppContextServiceProvider.php
+  - Symbol: AppContextServiceProvider::registerMiddleware(), AppContextServiceProvider::registerAuthenticators(), AppContextServiceProvider::registerVerifiers()
+  - Notes: registra pipeline y componentes.
+- File: src/Middleware/ResolveAppContext.php
+  - Symbol: ResolveAppContext::handle()
+  - Notes: resolución inicial de contexto.
+- File: src/Middleware/RateLimitByContext.php
+  - Symbol: RateLimitByContext::handle()
+  - Notes: rate limiting basado en contexto.
+- File: src/Middleware/AuthenticateChannel.php
+  - Symbol: AuthenticateChannel::handle()
+  - Notes: autenticación según `auth_mode`.
+- File: src/Middleware/EnforceContextBinding.php
+  - Symbol: EnforceContextBinding::handle()
+  - Notes: binding de audience/tenant.
+- File: src/Middleware/InjectAuditContext.php
+  - Symbol: InjectAuditContext::handle()
+  - Notes: logging con contexto.

--- a/documentation/ronu/laravel-app-context/docs/04-features/api-key-authentication.md
+++ b/documentation/ronu/laravel-app-context/docs/04-features/api-key-authentication.md
@@ -1,0 +1,63 @@
+# API Key Authentication
+
+## Overview
+Autentica integraciones B2B/M2M con headers `X-Client-Id` y `X-Api-Key`. Valida hash, expiración, revocación e IP allowlist (opcional) y construye `AppContext` con `clientId`, `capabilities` y metadata.
+
+## When to use / When NOT to use
+**Úsalo cuando:**
+- El canal es de partners externos sin usuarios finales.
+- Necesitas capabilities por cliente.
+
+**Evítalo cuando:**
+- El canal requiere identidad de usuario (usa `jwt`).
+
+## How it works
+- `ApiKeyVerifier` extrae headers y busca el cliente vía `ClientRepositoryInterface`.
+- Verifica hash, revocación y expiración; aplica IP allowlist.
+- `ApiKeyAuthenticator` filtra capabilities contra `allowed_capabilities` del canal.
+
+## Configuration
+Keys relevantes:
+- `api_key.headers.client_id` / `api_key.headers.api_key`
+- `api_key.hash_algorithm`
+- `security.enforce_ip_allowlist`
+- `client_repository.*`
+
+## Usage examples
+```php
+// routes/api.php
+Route::prefix('partner')
+    ->middleware(['app.context', 'app.auth', 'app.binding'])
+    ->group(function () {
+        Route::get('/inventory', [InventoryController::class, 'index'])
+            ->middleware('app.requires:partner:inventory:read');
+    });
+```
+
+```bash
+curl -H "X-Client-Id: acme" \
+     -H "X-Api-Key: prefix.secret" \
+     https://api.example.com/partner/inventory
+```
+
+## Edge cases / pitfalls
+- Si `enforce_ip_allowlist=true` y el allowlist está vacío, el request se rechaza.
+- En repo `config`, `create()` y `revoke()` no están soportados (runtime exception).
+
+## Evidence
+- File: src/Auth/Verifiers/ApiKeyVerifier.php
+  - Symbol: ApiKeyVerifier::verify(), ApiKeyVerifier::isIpAllowed()
+  - Notes: validación de credenciales e IP allowlist.
+- File: src/Auth/Authenticators/ApiKeyAuthenticator.php
+  - Symbol: ApiKeyAuthenticator::authenticate(), ApiKeyAuthenticator::buildCapabilities()
+  - Notes: filtro de capabilities por canal.
+- File: src/Repositories/ConfigClientRepository.php
+  - Symbol: ConfigClientRepository::create(), ConfigClientRepository::revoke()
+  - Notes: operaciones no soportadas en driver config.
+- File: config/app-context.php
+  - Symbol: api_key, security.enforce_ip_allowlist, client_repository
+  - Notes: configuración para API keys y repositorios.
+
+## Related docs
+- [Configuration](../02-configuration.md)
+- [Security](../05-security.md)

--- a/documentation/ronu/laravel-app-context/docs/04-features/app-context-object.md
+++ b/documentation/ronu/laravel-app-context/docs/04-features/app-context-object.md
@@ -1,0 +1,65 @@
+# AppContext Object (Facade + Trait)
+
+## Overview
+`AppContext` es un value object inmutable que representa identidad, permisos, tenant y metadata por request. Se expone vía Facade y el trait `HasAppContext` para controllers.
+
+## When to use / When NOT to use
+**Úsalo cuando:**
+- Necesitas leer `appId`, `userId`, `clientId`, `scopes` o `tenantId` en controllers/services.
+
+**Evítalo cuando:**
+- Tu lógica ya está completamente en middleware y no necesitas acceso en runtime.
+
+## How it works
+- `ResolveAppContext` crea y registra el `AppContext` en el request/IoC.
+- La Facade `AppContext` lee del contenedor `app-context`.
+- `HasAppContext` facilita helpers en controllers.
+
+## Configuration
+No requiere configuración específica.
+
+## Usage examples
+```php
+use Ronu\AppContext\Facades\AppContext;
+
+if (AppContext::isResolved()) {
+    $channel = AppContext::getAppId();
+}
+```
+
+```php
+use Ronu\AppContext\Traits\HasAppContext;
+
+class MyController extends Controller
+{
+    use HasAppContext;
+
+    public function index()
+    {
+        if ($this->isAuthenticated()) {
+            return $this->userId();
+        }
+    }
+}
+```
+
+## Edge cases / pitfalls
+- Si el middleware `app.context` no corre, el contexto no existe y la Facade puede devolver null.
+
+## Evidence
+- File: src/Context/AppContext.php
+  - Symbol: AppContext::fromChannel(), AppContext::fromJwt(), AppContext::fromApiKey()
+  - Notes: value object principal.
+- File: src/Facades/AppContext.php
+  - Symbol: AppContext::current(), AppContext::isResolved()
+  - Notes: acceso vía Facade.
+- File: src/Traits/HasAppContext.php
+  - Symbol: HasAppContext::context(), HasAppContext::isAuthenticated()
+  - Notes: helpers para controllers.
+- File: src/Middleware/ResolveAppContext.php
+  - Symbol: ResolveAppContext::handle()
+  - Notes: inyección en request/IoC.
+
+## Related docs
+- [Architecture](../03-architecture.md)
+- [Reference: middleware](../09-reference/middleware.md)

--- a/documentation/ronu/laravel-app-context/docs/04-features/audit-logging.md
+++ b/documentation/ronu/laravel-app-context/docs/04-features/audit-logging.md
@@ -1,0 +1,48 @@
+# Audit Logging
+
+## Overview
+Inyecta el `AppContext` en el logger y permite registrar requests/responses con redacción de headers sensibles.
+
+## When to use / When NOT to use
+**Úsalo cuando:**
+- Necesitas trazabilidad de requests por canal/usuario/cliente.
+- Cumples requisitos de auditoría o compliance.
+
+**Evítalo cuando:**
+- Quieres reducir logs por performance (deshabilita o ajusta configuración).
+
+## How it works
+- `InjectAuditContext` toma config base + overrides por canal.
+- `Log::shareContext()` agrega metadatos globales.
+- Opcionalmente loguea request/response y filtra headers sensibles.
+
+## Configuration
+Keys relevantes:
+- `audit.enabled`
+- `audit.log_all_requests`
+- `audit.include_request_body`
+- `audit.include_response_body`
+- `audit.sensitive_headers`
+- `channels.<channel>.audit.*`
+
+## Usage examples
+```php
+Route::middleware(['app.context', 'app.auth', 'app.audit'])
+    ->get('/admin/stats', [StatsController::class, 'index']);
+```
+
+## Edge cases / pitfalls
+- Evita habilitar `include_request_body` en endpoints con datos sensibles.
+- Asegura que `sensitive_headers` incluya `authorization` y `x-api-key`.
+
+## Evidence
+- File: src/Middleware/InjectAuditContext.php
+  - Symbol: InjectAuditContext::handle(), InjectAuditContext::filterHeaders(), InjectAuditContext::resolveConfig()
+  - Notes: inyección de contexto y redacción.
+- File: config/app-context.php
+  - Symbol: audit, channels.*.audit
+  - Notes: configuración base y por canal.
+
+## Related docs
+- [Security](../05-security.md)
+- [Reference: middleware](../09-reference/middleware.md)

--- a/documentation/ronu/laravel-app-context/docs/04-features/authorization-abilities.md
+++ b/documentation/ronu/laravel-app-context/docs/04-features/authorization-abilities.md
@@ -1,0 +1,51 @@
+# Authorization (abilities, scopes, capabilities)
+
+## Overview
+Permite exigir permisos por ruta usando scopes (JWT) o capabilities (API Key). Incluye middlewares para **OR** y **AND**.
+
+## When to use / When NOT to use
+**Úsalo cuando:**
+- Necesitas control granular por endpoint.
+- Quieres la misma sintaxis para JWT y API keys.
+
+**Evítalo cuando:**
+- Tu app no necesita autorización por permiso (solo auth básica).
+
+## How it works
+- `RequireAbility` valida **OR** (al menos uno).
+- `RequireAllAbilities` valida **AND** (todos).
+- `RequireScope` soporta scopes y capabilities como legado.
+
+## Configuration
+Keys relevantes:
+- `channels.<channel>.allowed_scopes`
+- `channels.<channel>.allowed_capabilities`
+
+## Usage examples
+```php
+Route::get('/admin/users', [UsersController::class, 'index'])
+    ->middleware('app.requires:admin:users:read');
+
+Route::post('/partner/orders', [OrdersController::class, 'store'])
+    ->middleware('app.requires.all:partner:orders:create,partner:orders:sign');
+```
+
+## Edge cases / pitfalls
+- `RequireAllAbilities` espera parámetros separados por coma (AND lógico).
+- `RequireScope` es útil para compatibilidad, pero `app.requires` es el recomendado.
+
+## Evidence
+- File: src/Middleware/RequireAbility.php
+  - Symbol: RequireAbility::handle()
+  - Notes: OR lógico.
+- File: src/Middleware/RequireAllAbilities.php
+  - Symbol: RequireAllAbilities::handle()
+  - Notes: AND lógico.
+- File: src/Middleware/RequireScope.php
+  - Symbol: RequireScope::handle()
+  - Notes: middleware legacy scopes/capabilities.
+
+## Related docs
+- [Reference: middleware](../09-reference/middleware.md)
+- [Feature: JWT Authentication](jwt-authentication.md)
+- [Feature: API Key Authentication](api-key-authentication.md)

--- a/documentation/ronu/laravel-app-context/docs/04-features/context-aware-resources.md
+++ b/documentation/ronu/laravel-app-context/docs/04-features/context-aware-resources.md
@@ -1,0 +1,50 @@
+# Context-Aware Resources
+
+## Overview
+`ContextAwareResource` es una base para `JsonResource` que **adapta campos** según el canal (`admin`, `mobile`, `site`, `partner`).
+
+## When to use / When NOT to use
+**Úsalo cuando:**
+- Quieres respuestas diferentes por canal sin duplicar recursos.
+
+**Evítalo cuando:**
+- Todos los canales deben ver exactamente el mismo shape.
+
+## How it works
+- `toArray()` revisa `app_context` del request.
+- Llama a `toAdminArray`, `toMobileArray`, etc.
+- Provee helpers para scopes/capabilities y channel checks.
+
+## Configuration
+No requiere config; depende de `AppContext` resuelto en el request.
+
+## Usage examples
+```php
+use Ronu\AppContext\Resources\ContextAwareResource;
+
+class UserResource extends ContextAwareResource
+{
+    protected function toPublicArray(Request $request): array
+    {
+        return ['id' => $this->id, 'name' => $this->name];
+    }
+
+    protected function toFullArray(Request $request): array
+    {
+        return [...$this->toPublicArray($request), 'email' => $this->email];
+    }
+}
+```
+
+## Edge cases / pitfalls
+- Si no hay `AppContext`, cae a `toPublicArray()`.
+- Para admin, `toAdminArray()` llama a `toFullArray()` por defecto.
+
+## Evidence
+- File: src/Resources/ContextAwareResource.php
+  - Symbol: ContextAwareResource::toArray(), ContextAwareResource::whenHasScope()
+  - Notes: selección por canal y helpers.
+
+## Related docs
+- [Feature: Authorization](authorization-abilities.md)
+- [Architecture](../03-architecture.md)

--- a/documentation/ronu/laravel-app-context/docs/04-features/context-binding.md
+++ b/documentation/ronu/laravel-app-context/docs/04-features/context-binding.md
@@ -1,0 +1,46 @@
+# Context Binding (audience + tenant)
+
+## Overview
+Valida que el token o API key coincidan con el canal esperado y con el tenant del request. Previene ataques de **token reuse** y **cross-tenant access**.
+
+## When to use / When NOT to use
+**Úsalo cuando:**
+- Tienes multi-tenant y necesitas aislamiento estricto.
+- Sirves múltiples canales con tokens específicos por canal.
+
+**Evítalo cuando:**
+- Estás en una fase inicial y necesitas tolerancia (aunque se recomienda mantenerlo).
+
+## How it works
+- `EnforceContextBinding` verifica:
+  - JWT: `aud` vs `AppContext::appId`
+  - Tenant: `tid` vs tenant extraído de ruta/header/query
+- Para `api_key`, valida tenant del request contra `client.tenantId`.
+
+## Configuration
+Keys relevantes:
+- `jwt.verify_aud`
+- `security.enforce_tenant_binding`
+- `channels.<channel>.tenant_mode`
+
+## Usage examples
+```php
+Route::middleware(['app.context', 'app.auth', 'app.binding'])
+    ->get('/tenant/{tenant_id}/orders', [OrdersController::class, 'index']);
+```
+
+## Edge cases / pitfalls
+- En `tenant_mode=multi`, si el token no tiene `tid`, se lanza `missingTenant()`.
+- Si el request no incluye tenant, no hay validación de binding.
+
+## Evidence
+- File: src/Middleware/EnforceContextBinding.php
+  - Symbol: EnforceContextBinding::handle(), EnforceContextBinding::validateJwtBinding(), EnforceContextBinding::validateTenantBinding()
+  - Notes: validación de audience y tenant.
+- File: config/app-context.php
+  - Symbol: jwt.verify_aud, security.enforce_tenant_binding, channels.*.tenant_mode
+  - Notes: toggles de binding.
+
+## Related docs
+- [Security](../05-security.md)
+- [Reference: exceptions](../09-reference/exceptions.md)

--- a/documentation/ronu/laravel-app-context/docs/04-features/context-resolution.md
+++ b/documentation/ronu/laravel-app-context/docs/04-features/context-resolution.md
@@ -1,0 +1,55 @@
+# Context Resolution (channel detection)
+
+## Overview
+Resuelve el **canal** (mobile/admin/site/partner) a partir de host y path para construir el `AppContext` base. Esto evita confiar en headers no firmados y define el `auth_mode` inicial del request.
+
+## When to use / When NOT to use
+**Úsalo cuando:**
+- Necesitas separar flujos por canal (subdominio o prefijo de path).
+- Quieres evitar spoofing de canal (headers no confiables).
+
+**Evítalo cuando:**
+- Tu app no tiene múltiples canales (una API simple puede usar auth estándar).
+
+## How it works
+- `ContextResolver` evalúa `detection_strategy` (`auto`, `path`, `subdomain`, `strict`).
+- `ResolveAppContext` crea `AppContext` y lo inyecta en el request + container.
+- Si `deny_by_default=true` y no hay canal, lanza excepción.
+
+## Configuration
+Keys relevantes:
+- `detection_strategy`
+- `auto_detection_rules`
+- `domain`
+- `channels.*.subdomains`
+- `channels.*.path_prefixes`
+- `deny_by_default`
+- `default_channel`
+
+## Usage examples
+```php
+// routes/api.php
+Route::middleware(['app.context'])->group(function () {
+    // Dentro ya existe AppContext
+});
+```
+
+## Edge cases / pitfalls
+- `domain` incorrecto rompe la extracción de subdominio en producción.
+- En `strict`, subdominio y path deben coincidir con el mismo canal.
+- Si `deny_by_default=true`, rutas sin canal configurado devolverán 403.
+
+## Evidence
+- File: src/Context/ContextResolver.php
+  - Symbol: ContextResolver::resolve(), ContextResolver::resolveAuto(), ContextResolver::extractSubdomain()
+  - Notes: estrategia de detección por host/path.
+- File: src/Middleware/ResolveAppContext.php
+  - Symbol: ResolveAppContext::handle()
+  - Notes: creación e inyección del AppContext.
+- File: config/app-context.php
+  - Symbol: detection_strategy, auto_detection_rules, domain, channels, deny_by_default, default_channel
+  - Notes: configuración de resolución por canal.
+
+## Related docs
+- [Configuration](../02-configuration.md)
+- [Architecture](../03-architecture.md)

--- a/documentation/ronu/laravel-app-context/docs/04-features/contextual-eloquent-scopes.md
+++ b/documentation/ronu/laravel-app-context/docs/04-features/contextual-eloquent-scopes.md
@@ -1,0 +1,44 @@
+# Contextual Eloquent Scopes
+
+## Overview
+El trait `ContextualScopes` aplica filtros automáticos por tenant y usuario en modelos Eloquent, y puede autocompletar `tenant_id` y `user_id` en `creating`.
+
+## When to use / When NOT to use
+**Úsalo cuando:**
+- Necesitas aislamiento multi-tenant y/o multi-user a nivel de modelo.
+
+**Evítalo cuando:**
+- Tu app no tiene tenant/user en tablas o usas filtros manuales complejos.
+
+## How it works
+- `scopeForContext()` filtra por `tenant_id` y (si no es admin) `user_id`.
+- `bootContextualScopes()` autopuebla columnas si están disponibles.
+
+## Configuration
+No requiere config. Puede personalizar columnas con `$tenantColumn` y `$userColumn` en el modelo.
+
+## Usage examples
+```php
+use Ronu\AppContext\Traits\ContextualScopes;
+
+class Order extends Model
+{
+    use ContextualScopes;
+}
+
+// En controlador
+Order::forContext()->get();
+Order::forTenant()->get();
+```
+
+## Edge cases / pitfalls
+- El trait detecta columnas via `fillable` o `Schema`.
+- En canal `admin`, `scopeForContext()` mantiene filtros de tenant/user solo si no es admin.
+
+## Evidence
+- File: src/Traits/ContextualScopes.php
+  - Symbol: ContextualScopes::scopeForContext(), ContextualScopes::bootContextualScopes()
+  - Notes: filtros y auto-fill.
+
+## Related docs
+- [Feature: Context Resolution](context-resolution.md)

--- a/documentation/ronu/laravel-app-context/docs/04-features/jwt-authentication.md
+++ b/documentation/ronu/laravel-app-context/docs/04-features/jwt-authentication.md
@@ -1,0 +1,65 @@
+# JWT Authentication
+
+## Overview
+Autentica usuarios con JWT, valida firma, algoritmo permitido, issuer y audience. Construye el `AppContext` con `userId`, `tenantId`, `scopes` y metadata de claims.
+
+## When to use / When NOT to use
+**Úsalo cuando:**
+- Necesitas auth basada en tokens para canales `jwt`.
+- Quieres scopes por usuario y validación de issuer/audience.
+
+**Evítalo cuando:**
+- El canal sea exclusivamente M2M (usa `api_key`).
+
+## How it works
+- `JwtVerifier` extrae token de header/query/cookie según `token_sources`.
+- `preVerify` valida estructura y algoritmo (rechaza `none`).
+- `postVerify` valida `aud`, `iss`, `sub` y blacklist.
+- `JwtAuthenticator` carga usuario (`Auth::getProvider()`), resuelve scopes y crea `AppContext`.
+
+## Configuration
+Keys relevantes:
+- `jwt.algorithm`, `jwt.allowed_algorithms`
+- `jwt.issuer`, `jwt.verify_iss`, `jwt.ignore_issuer_scheme`
+- `jwt.verify_aud`
+- `jwt.token_sources`
+- `jwt.blacklist_enabled`
+
+## Usage examples
+```php
+// routes/api.php
+Route::middleware(['app.context', 'app.auth', 'app.binding'])
+    ->get('/api/me', [MeController::class, 'show'])
+    ->middleware('app.requires:admin:users:read');
+```
+
+```php
+// Emisión de token con claims mínimos
+$claims = [
+    'aud' => $context->getAppId(),
+    'tid' => $request->header('X-Tenant-Id'),
+    'scp' => ['admin:*'],
+];
+
+$token = JWTAuth::claims($claims)->fromUser($user);
+```
+
+## Edge cases / pitfalls
+- `JWT_IGNORE_ISSUER_SCHEME` es útil detrás de reverse proxy.
+- Si falta `aud` y `verify_aud=true`, se rechaza el token.
+- Si falta `sub`, el token se considera inválido.
+
+## Evidence
+- File: src/Auth/Verifiers/JwtVerifier.php
+  - Symbol: JwtVerifier::verify(), JwtVerifier::preVerify(), JwtVerifier::postVerify()
+  - Notes: validaciones JWT y manejo de blacklist/issuer/audience.
+- File: src/Auth/Authenticators/JwtAuthenticator.php
+  - Symbol: JwtAuthenticator::authenticate(), JwtAuthenticator::authenticateWithToken()
+  - Notes: carga de usuario y construcción de scopes.
+- File: config/app-context.php
+  - Symbol: jwt
+  - Notes: configuración JWT.
+
+## Related docs
+- [Security](../05-security.md)
+- [Reference: config keys](../09-reference/config-keys.md)

--- a/documentation/ronu/laravel-app-context/docs/04-features/module-route-loader.md
+++ b/documentation/ronu/laravel-app-context/docs/04-features/module-route-loader.md
@@ -1,0 +1,38 @@
+# Module Route Loader (HelpersRouting)
+
+## Overview
+`HelpersRouting::loadModuleRoutes()` permite cargar archivos de rutas por patrón `glob` y aplicar namespace automáticamente para módulos.
+
+## When to use / When NOT to use
+**Úsalo cuando:**
+- Tu app organiza rutas por módulos en carpetas (e.g. `modules/*/Routes/api.php`).
+
+**Evítalo cuando:**
+- No usas arquitectura modular basada en filesystem.
+
+## How it works
+- Busca archivos con `glob()`.
+- Deriva el namespace `Modules\<Module>\Http\Controllers`.
+- Agrupa rutas con `Route::group()`.
+
+## Configuration
+No requiere configuración. Se invoca desde tu propio `routes/*.php` o service provider.
+
+## Usage examples
+```php
+use Ronu\AppContext\Helpers\HelpersRouting;
+
+HelpersRouting::loadModuleRoutes('modules/*/Routes/api.php', 'admin');
+```
+
+## Edge cases / pitfalls
+- Asume que el nombre del directorio del módulo coincide con el namespace.
+- Solo funciona si la estructura de carpetas coincide con el patrón esperado.
+
+## Evidence
+- File: src/Helpers/HelpersRouting.php
+  - Symbol: HelpersRouting::loadModuleRoutes()
+  - Notes: carga de rutas por patrón y namespace.
+
+## Related docs
+- [Architecture](../03-architecture.md)

--- a/documentation/ronu/laravel-app-context/docs/04-features/optional-anonymous-access.md
+++ b/documentation/ronu/laravel-app-context/docs/04-features/optional-anonymous-access.md
@@ -1,0 +1,64 @@
+# Optional Anonymous Access (jwt_or_anonymous)
+
+## Overview
+Permite rutas públicas con **auth opcional**: si hay token, lo valida; si no hay (o si el canal permite fallback), crea un `AppContext` anónimo con scopes públicos.
+
+## When to use / When NOT to use
+**Úsalo cuando:**
+- Tienes catálogo público con personalización para usuarios autenticados.
+- Quieres permitir navegación sin token, pero aprovechar scopes si existen.
+
+**Evítalo cuando:**
+- Necesitas seguridad estricta; usa `jwt` y elimina fallback.
+
+## How it works
+- `JwtAuthenticator` detecta si la ruta es pública o si el canal permite `allow_anonymous`.
+- En `jwt_or_anonymous`, usa `tryAuthenticate()` y crea contexto anónimo con `PublicScopeResolver` si no hay token.
+
+## Configuration
+Keys relevantes:
+- `channels.<channel>.auth_mode = jwt_or_anonymous`
+- `channels.<channel>.public_scopes`
+- `channels.<channel>.anonymous_on_invalid_token`
+- `channels.<channel>.features.allow_anonymous`
+- `public_routes.*`
+
+## Usage examples
+```php
+// config/app-context.php
+'site' => [
+    'auth_mode' => 'jwt_or_anonymous',
+    'public_scopes' => ['catalog:browse', 'public:read'],
+    'anonymous_on_invalid_token' => false,
+],
+```
+
+```php
+public function catalog(AppContext $context)
+{
+    if ($context->isAuthenticated()) {
+        return $this->personalizedCatalog($context->getUserId());
+    }
+
+    return $this->publicCatalog();
+}
+```
+
+## Edge cases / pitfalls
+- Si `anonymous_on_invalid_token=false`, un token inválido **bloquea** el request.
+- Si `public_scopes` está vacío, el resolver usa scopes seguros por defecto (`public:read`, `catalog:browse`).
+
+## Evidence
+- File: src/Auth/Authenticators/JwtAuthenticator.php
+  - Symbol: JwtAuthenticator::tryAuthenticate(), JwtAuthenticator::buildAnonymousContext(), JwtAuthenticator::shouldFallbackOnInvalidToken()
+  - Notes: fallback a contexto anónimo y reglas de invalid token.
+- File: src/Support/PublicScopeResolver.php
+  - Symbol: PublicScopeResolver::resolve()
+  - Notes: scopes públicos por canal.
+- File: config/app-context.php
+  - Symbol: channels.*.auth_mode, channels.*.public_scopes, channels.*.anonymous_on_invalid_token, public_routes
+  - Notes: configuración para auth opcional.
+
+## Related docs
+- [Configuration](../02-configuration.md)
+- [Security](../05-security.md)

--- a/documentation/ronu/laravel-app-context/docs/04-features/rate-limiting.md
+++ b/documentation/ronu/laravel-app-context/docs/04-features/rate-limiting.md
@@ -1,0 +1,63 @@
+# Rate Limiting por contexto
+
+## Overview
+Aplica límites por canal, endpoint y contexto (user, client, IP). Soporta burst limits y headers estándar.
+
+## When to use / When NOT to use
+**Úsalo cuando:**
+- Necesitas proteger endpoints críticos por canal.
+- Debes diferenciar límites entre autenticados y anónimos.
+
+**Evítalo cuando:**
+- No tienes tráfico significativo o usas otro sistema de rate limiting centralizado.
+
+## How it works
+- `RateLimitByContext` lee perfil por canal (`rate_limits`).
+- Determina la clave según `by` (user, client_id, ip, user_device).
+- Aplica límites globales o específicos por endpoint.
+
+## Configuration
+Keys relevantes:
+- `rate_limits.<profile>.global`
+- `rate_limits.<profile>.authenticated_global`
+- `rate_limits.<profile>.by`
+- `rate_limits.<profile>.burst`
+- `rate_limits.<profile>.endpoints`
+- `channels.<channel>.rate_limit_profile`
+
+## Usage examples
+```php
+// config/app-context.php
+'rate_limits' => [
+    'admin' => [
+        'global' => '120/m',
+        'by' => 'user',
+        'burst' => '20/s',
+        'endpoints' => [
+            'GET:/api/reports/export' => '5/m',
+        ],
+    ],
+],
+```
+
+```php
+Route::middleware(['app.context', 'app.throttle'])->group(function () {
+    // rutas con rate limiting por contexto
+});
+```
+
+## Edge cases / pitfalls
+- Si usas `app.throttle`, evita doble rate limiting con `throttle:api`.
+- `endpoint` soporta `*` por segmento, no regex completo.
+
+## Evidence
+- File: src/Middleware/RateLimitByContext.php
+  - Symbol: RateLimitByContext::handle(), RateLimitByContext::getRateLimitConfig(), RateLimitByContext::matchEndpoint()
+  - Notes: implementación de rate limiting y patrones.
+- File: config/app-context.php
+  - Symbol: rate_limits, channels.*.rate_limit_profile
+  - Notes: perfiles y binding a canales.
+
+## Related docs
+- [Configuration](../02-configuration.md)
+- [Security](../05-security.md)

--- a/documentation/ronu/laravel-app-context/docs/05-security.md
+++ b/documentation/ronu/laravel-app-context/docs/05-security.md
@@ -1,0 +1,52 @@
+# Security
+
+## Resumen
+El paquete implementa controles de seguridad en varios puntos: verificación estricta de JWT (algoritmo, issuer, audience, blacklist), validación de API keys (hash, expiración, revocación, IP allowlist) y binding de tenant/canal.
+
+## Controles clave
+### 1) JWT hardening
+- Rechazo de algoritmo `none` y whitelist de algoritmos.
+- Validación de `aud` y `iss`.
+- Blacklist opcional con cache.
+
+### 2) API Key hardening
+- Hash `argon2id` (recomendado).
+- Expiración y revocación.
+- IP allowlist opcional (y forzado si `enforce_ip_allowlist=true`).
+
+### 3) Context binding
+- `aud` debe coincidir con el canal.
+- `tenant_id` debe coincidir con el request cuando `tenant_mode=multi`.
+
+### 4) Audit logging
+- `InjectAuditContext` añade metadata en logs y permite redacción de headers sensibles.
+
+## Pitfalls comunes
+- `JWT_IGNORE_ISSUER_SCHEME` debe habilitarse detrás de reverse proxies si cambian `http/https`.
+- Si `anonymous_on_invalid_token=false`, un JWT inválido en `jwt_or_anonymous` rechaza la petición.
+- Si `enforce_ip_allowlist=true` y el allowlist está vacío, el request fallará.
+
+## Checklist recomendado
+- [ ] `deny_by_default=true`
+- [ ] `jwt.verify_aud=true`, `jwt.verify_iss=true`
+- [ ] `jwt.allowed_algorithms` sin `none`
+- [ ] `security.enforce_tenant_binding=true`
+- [ ] `api_key.hash_algorithm=argon2id`
+- [ ] `audit.log_failed_auth=true`
+
+## Evidence
+- File: src/Auth/Verifiers/JwtVerifier.php
+  - Symbol: JwtVerifier::preVerify(), JwtVerifier::postVerify()
+  - Notes: validación de algoritmos, issuer/audience y blacklist.
+- File: src/Auth/Verifiers/ApiKeyVerifier.php
+  - Symbol: ApiKeyVerifier::verify(), ApiKeyVerifier::isIpAllowed()
+  - Notes: hash, revocación, expiración, allowlist.
+- File: src/Middleware/EnforceContextBinding.php
+  - Symbol: EnforceContextBinding::validateJwtBinding(), EnforceContextBinding::validateTenantBinding()
+  - Notes: binding de canal y tenant.
+- File: src/Middleware/InjectAuditContext.php
+  - Symbol: InjectAuditContext::filterHeaders()
+  - Notes: redacción de headers sensibles.
+- File: config/app-context.php
+  - Symbol: jwt, api_key, security, audit
+  - Notes: configuración de seguridad.

--- a/documentation/ronu/laravel-app-context/docs/06-testing.md
+++ b/documentation/ronu/laravel-app-context/docs/06-testing.md
@@ -1,0 +1,21 @@
+# Testing
+
+## Enfoque de tests
+Hay tests unitarios para `AppContext`, `ContextResolver`, middleware y repositorios. Se ejecutan con PHPUnit vía `composer test`.
+
+## Comandos
+```bash
+composer test
+composer test-coverage
+```
+
+## Evidence
+- File: composer.json
+  - Symbol: scripts.test, scripts.test-coverage
+  - Notes: comandos oficiales de test.
+- File: tests/Unit/AppContextTest.php
+  - Symbol: AppContextTest
+  - Notes: ejemplos de tests unitarios.
+- File: tests/Unit/ContextResolverTest.php
+  - Symbol: ContextResolverTest
+  - Notes: cobertura de resolución de canal.

--- a/documentation/ronu/laravel-app-context/docs/07-troubleshooting.md
+++ b/documentation/ronu/laravel-app-context/docs/07-troubleshooting.md
@@ -1,0 +1,34 @@
+# Troubleshooting
+
+## Problemas comunes
+### 1) “Request does not match any configured channel”
+Causa: `deny_by_default=true` y no hay canal para host/path.
+Solución: revisa `channels` y `domain`/`detection_strategy`.
+
+### 2) “Token audience mismatch”
+Causa: `aud` no coincide con el canal.
+Solución: emite tokens con `aud = AppContext::getAppId()`.
+
+### 3) “Tenant mismatch / missing tenant”
+Causa: `tenant_mode=multi` y el token no tiene `tid` o no coincide con el request.
+Solución: incluir `tid` en claims y enviar `tenant_id` por ruta/header/query.
+
+### 4) “API key required”
+Causa: headers faltantes (`X-Client-Id`, `X-Api-Key`).
+
+## Discrepancias con docs existentes
+- `docs/Documentation.md` menciona comandos `app-context:generate-key`, `app-context:list-clients`, `app-context:revoke-key` como “planned”, pero **el único comando implementado** es `route:channel`.
+
+## Evidence
+- File: src/Exceptions/ContextBindingException.php
+  - Symbol: ContextBindingException::denyByDefault(), ContextBindingException::audienceMismatch(), ContextBindingException::missingTenant(), ContextBindingException::tenantMismatch()
+  - Notes: errores frecuentes de binding.
+- File: src/Exceptions/AuthenticationException.php
+  - Symbol: AuthenticationException::missingApiKey()
+  - Notes: error típico cuando faltan headers de API key.
+- File: src/Commands/RoutesByChannel.php
+  - Symbol: RoutesByChannel
+  - Notes: único comando real en el paquete.
+- File: docs/Documentation.md
+  - Symbol: “Artisan Commands” section
+  - Notes: lista de comandos planificados no implementados.

--- a/documentation/ronu/laravel-app-context/docs/08-faq.md
+++ b/documentation/ronu/laravel-app-context/docs/08-faq.md
@@ -1,0 +1,27 @@
+# FAQ
+
+### ¿Cómo obtengo el AppContext actual?
+Puedes usar la Facade `AppContext` o el trait `HasAppContext` en controllers.
+
+### ¿Qué middleware debo usar primero?
+`app.context` debe correr antes de `app.auth`, `app.binding` y `app.audit`.
+
+### ¿Cómo habilito auth opcional?
+Configura el canal con `auth_mode=jwt_or_anonymous` y define `public_scopes`.
+
+### ¿El paquete incluye rutas propias?
+No. Debes definir las rutas de tu aplicación e incluir el middleware correspondiente.
+
+## Evidence
+- File: src/Facades/AppContext.php
+  - Symbol: AppContext::current(), AppContext::isResolved()
+  - Notes: acceso al contexto actual.
+- File: src/Traits/HasAppContext.php
+  - Symbol: HasAppContext::context()
+  - Notes: helpers para controllers.
+- File: src/AppContextServiceProvider.php
+  - Symbol: AppContextServiceProvider::registerMiddleware()
+  - Notes: alias y group de middleware.
+- File: src/Auth/Authenticators/JwtAuthenticator.php
+  - Symbol: JwtAuthenticator::tryAuthenticate()
+  - Notes: auth opcional con `jwt_or_anonymous`.

--- a/documentation/ronu/laravel-app-context/docs/09-reference/artisan-commands.md
+++ b/documentation/ronu/laravel-app-context/docs/09-reference/artisan-commands.md
@@ -1,0 +1,20 @@
+# Artisan Commands
+
+## route:channel
+Lista rutas por canal (admin/site/mobile/partner) o rutas huérfanas.
+
+```bash
+php artisan route:channel admin
+php artisan route:channel mobile --json
+php artisan route:channel --orphans
+```
+
+### Parámetros
+- `channel`: `admin|site|mobile|partner`
+- `--orphans`: rutas que no pertenecen a ningún canal
+- `--json`: salida JSON
+
+## Evidence
+- File: src/Commands/RoutesByChannel.php
+  - Symbol: RoutesByChannel::handle(), RoutesByChannel::$signature
+  - Notes: definición del comando y opciones.

--- a/documentation/ronu/laravel-app-context/docs/09-reference/config-keys.md
+++ b/documentation/ronu/laravel-app-context/docs/09-reference/config-keys.md
@@ -1,0 +1,104 @@
+# Config Keys Reference
+
+Archivo: `config/app-context.php`.
+
+## Core
+| Key | Tipo | Descripción |
+| --- | --- | --- |
+| `deny_by_default` | bool | Bloquea requests sin canal reconocido. |
+| `default_channel` | string | Canal default si `deny_by_default=false`. |
+| `domain` | string | Dominio base para extraer subdominio. |
+| `detection_strategy` | string | `auto`, `path`, `subdomain`, `strict`. |
+| `auto_detection_rules` | array | Reglas host → estrategia. |
+| `app_context_dev` | array | Envs dev para resolver por path. |
+
+## Client repository
+| Key | Tipo | Descripción |
+| --- | --- | --- |
+| `client_repository.driver` | string | `config`, `eloquent` o clase custom. |
+| `client_repository.config` | array | Clientes en config. |
+| `client_repository.eloquent` | array | Tablas/modelos para DB. |
+
+## Channels
+| Key | Tipo | Descripción |
+| --- | --- | --- |
+| `channels.*.subdomains` | array | Subdominios válidos. |
+| `channels.*.path_prefixes` | array | Prefijos de path. |
+| `channels.*.auth_mode` | string | `jwt`, `api_key`, `anonymous`, `jwt_or_anonymous`. |
+| `channels.*.jwt_audience` | string | Audiencia esperada. |
+| `channels.*.allowed_scopes` | array | Scopes permitidos. |
+| `channels.*.allowed_capabilities` | array | Capabilities permitidas. |
+| `channels.*.public_scopes` | array | Scopes públicos. |
+| `channels.*.anonymous_on_invalid_token` | bool | Fallback para token inválido. |
+| `channels.*.rate_limit_profile` | string | Perfil de rate limit. |
+| `channels.*.tenant_mode` | string | `single`/`multi`. |
+| `channels.*.features` | array | Flags por canal. |
+| `channels.*.audit` | array | Overrides de audit. |
+
+## JWT
+| Key | Tipo | Descripción |
+| --- | --- | --- |
+| `jwt.algorithm` | string | `HS256`/`RS256`. |
+| `jwt.public_key_path` | string | Ruta de clave pública. |
+| `jwt.private_key_path` | string | Ruta de clave privada. |
+| `jwt.issuer` | string | Issuer esperado. |
+| `jwt.ttl` | int | TTL en segundos. |
+| `jwt.refresh_ttl` | int | TTL de refresh. |
+| `jwt.blacklist_enabled` | bool | Blacklist activa. |
+| `jwt.verify_iss` | bool | Validar issuer. |
+| `jwt.ignore_issuer_scheme` | bool | Ignorar esquema http/https. |
+| `jwt.verify_aud` | bool | Validar audiencia. |
+| `jwt.allowed_algorithms` | array | Algoritmos permitidos. |
+| `jwt.token_sources` | array | `header`, `query`, `cookie`. |
+| `jwt.dev_fallback` | array | Fallback para dev. |
+
+## API Key
+| Key | Tipo | Descripción |
+| --- | --- | --- |
+| `api_key.hash_algorithm` | string | Algoritmo de hash. |
+| `api_key.headers.client_id` | string | Header client ID. |
+| `api_key.headers.api_key` | string | Header API key. |
+| `api_key.rotation_days` | int | Rotación de keys. |
+| `api_key.expiration_warning_days` | int | Días de warning. |
+| `api_key.max_keys_per_client` | int | Máximo keys por cliente. |
+
+## Rate limits
+| Key | Tipo | Descripción |
+| --- | --- | --- |
+| `rate_limits.*.global` | string | Límite global. |
+| `rate_limits.*.authenticated_global` | string | Límite para autenticados. |
+| `rate_limits.*.by` | string | Estrategia de key. |
+| `rate_limits.*.burst` | string | Límite burst. |
+| `rate_limits.*.endpoints` | array | Límite por endpoint. |
+
+## Security
+| Key | Tipo | Descripción |
+| --- | --- | --- |
+| `security.strict_algorithm_check` | bool | Whitelist estricta de algoritmos. |
+| `security.enforce_tenant_binding` | bool | Enforce tenant binding. |
+| `security.enforce_ip_allowlist` | bool | Enforce allowlist. |
+| `security.anomaly_detection` | array | Flags de anomalías. |
+
+## Audit
+| Key | Tipo | Descripción |
+| --- | --- | --- |
+| `audit.enabled` | bool | Activar auditoría. |
+| `audit.log_channel` | string | Canal de log. |
+| `audit.include_request_body` | bool | Log de body request. |
+| `audit.include_response_body` | bool | Log de body response. |
+| `audit.log_all_requests` | bool | Log de todas las requests. |
+| `audit.log_responses` | bool | Log de responses. |
+| `audit.log_failed_auth` | bool | Log de auth fallida. |
+| `audit.sensitive_headers` | array | Headers a redactar. |
+
+## Public routes
+| Key | Tipo | Descripción |
+| --- | --- | --- |
+| `public_routes.names` | array | Rutas públicas por nombre. |
+| `public_routes.name_endings` | array | Rutas públicas por sufijo de nombre. |
+| `public_routes.path_endings` | array | Rutas públicas por sufijo de path. |
+
+## Evidence
+- File: config/app-context.php
+  - Symbol: (archivo completo)
+  - Notes: source oficial de todas las keys.

--- a/documentation/ronu/laravel-app-context/docs/09-reference/env-vars.md
+++ b/documentation/ronu/laravel-app-context/docs/09-reference/env-vars.md
@@ -1,0 +1,60 @@
+# Environment Variables
+
+Variables leídas por `config/app-context.php`.
+
+| Env var | Descripción |
+| --- | --- |
+| `APP_CONTEXT_CLIENT_DRIVER` | Driver de clientes (`config`/`eloquent`). |
+| `API_KEY_HASH_ALGO` | Hash para API keys. |
+| `APP_CONTEXT_CLIENTS_TABLE` | Tabla legacy `api_clients`. |
+| `APP_CONTEXT_APPS_TABLE` | Tabla `api_apps`. |
+| `APP_CONTEXT_APP_KEYS_TABLE` | Tabla `api_app_keys`. |
+| `APP_CONTEXT_APP_MODEL` | Modelo Eloquent custom (apps). |
+| `APP_CONTEXT_APP_KEY_MODEL` | Modelo Eloquent custom (keys). |
+| `APP_CONTEXT_CLIENTS_CONNECTION` | Conexión DB para clientes. |
+| `APP_CONTEXT_DENY_BY_DEFAULT` | Toggle `deny_by_default`. |
+| `APP_CONTEXT_DEFAULT_CHANNEL` | Canal default. |
+| `APP_CONTEXT_DOMAIN` | Dominio base. |
+| `APP_DOMAIN` | Fallback para dominio base. |
+| `APP_CONTEXT_DETECTION` | Estrategia de detección. |
+| `APP_CONTEXT_DEV` | Envs que usan path en auto-detection. |
+| `ADMIN_MFA_REQUIRED` | Flag de ejemplo en canal admin. |
+| `RATE_LIMIT_MOBILE_GLOBAL` | Límite global móvil. |
+| `RATE_LIMIT_ADMIN_GLOBAL` | Límite global admin. |
+| `RATE_LIMIT_SITE_ANON` | Límite anónimo site. |
+| `RATE_LIMIT_SITE_AUTH` | Límite autenticado site. |
+| `RATE_LIMIT_PARTNER_GLOBAL` | Límite global partner. |
+| `JWT_ALGO` | Algoritmo JWT. |
+| `JWT_PUBLIC_KEY_PATH` | Ruta clave pública. |
+| `JWT_PRIVATE_KEY_PATH` | Ruta clave privada. |
+| `JWT_ISSUER` | Issuer esperado. |
+| `JWT_TTL` | TTL del token. |
+| `JWT_REFRESH_TTL` | TTL de refresh. |
+| `JWT_BLACKLIST_ENABLED` | Blacklist habilitada. |
+| `JWT_VERIFY_ISS` | Validar issuer. |
+| `JWT_IGNORE_ISSUER_SCHEME` | Ignorar esquema http/https. |
+| `JWT_VERIFY_AUD` | Validar audiencia. |
+| `JWT_TOKEN_SOURCES` | Fuentes de token. |
+| `JWT_DEV_FALLBACK` | Fallback dev. |
+| `JWT_DEV_ALGO` | Algoritmo de fallback. |
+| `JWT_DEV_SECRET` | Secret de fallback. |
+| `API_KEY_CLIENT_ID_HEADER` | Header client ID. |
+| `API_KEY_HEADER` | Header API key. |
+| `API_KEY_ROTATION_DAYS` | Días de rotación. |
+| `API_KEY_WARNING_DAYS` | Días de warning. |
+| `API_KEY_MAX_PER_CLIENT` | Max keys por cliente. |
+| `APP_CONTEXT_TENANT_BINDING` | Enforce tenant binding. |
+| `APP_CONTEXT_IP_ALLOWLIST` | Enforce IP allowlist. |
+| `APP_CONTEXT_ANOMALY_DETECTION` | Toggle de anomalías. |
+| `APP_CONTEXT_AUDIT` | Habilitar audit. |
+| `APP_CONTEXT_LOG_CHANNEL` | Canal de logs. |
+| `APP_CONTEXT_LOG_BODY` | Log de body request. |
+| `APP_CONTEXT_LOG_RESPONSE` | Log de body response. |
+| `APP_CONTEXT_LOG_ALL` | Log de todas las requests. |
+| `APP_CONTEXT_LOG_RESPONSES` | Log de responses. |
+| `APP_CONTEXT_LOG_FAILED_AUTH` | Log de auth fallida. |
+
+## Evidence
+- File: config/app-context.php
+  - Symbol: env(...) usages
+  - Notes: todas las variables de entorno consumidas.

--- a/documentation/ronu/laravel-app-context/docs/09-reference/exceptions.md
+++ b/documentation/ronu/laravel-app-context/docs/09-reference/exceptions.md
@@ -1,0 +1,27 @@
+# Exceptions Reference
+
+## AppContextException
+Base para errores del paquete. Renderiza JSON con `error`, `message` y `context`.
+
+## AuthenticationException (401)
+Errores de credenciales: token inválido, API key faltante, blacklist, etc.
+
+## AuthorizationException (403)
+Errores de permisos: scopes/capabilities faltantes.
+
+## ContextBindingException (403)
+Errores de binding: audience, tenant o canal inválidos, o `deny_by_default`.
+
+## Evidence
+- File: src/Exceptions/AppContextException.php
+  - Symbol: AppContextException::render()
+  - Notes: formato JSON y status code.
+- File: src/Exceptions/AuthenticationException.php
+  - Symbol: AuthenticationException::*
+  - Notes: errores 401 específicos.
+- File: src/Exceptions/AuthorizationException.php
+  - Symbol: AuthorizationException::*
+  - Notes: errores 403 por permisos.
+- File: src/Exceptions/ContextBindingException.php
+  - Symbol: ContextBindingException::*
+  - Notes: errores 403 de binding.

--- a/documentation/ronu/laravel-app-context/docs/09-reference/middleware.md
+++ b/documentation/ronu/laravel-app-context/docs/09-reference/middleware.md
@@ -1,0 +1,32 @@
+# Middleware Reference
+
+## Aliases registrados
+| Alias | Clase | Propósito |
+| --- | --- | --- |
+| `app.context` | ResolveAppContext | Resuelve canal y crea AppContext. |
+| `app.auth` | AuthenticateChannel | Autenticación según canal. |
+| `app.binding` | EnforceContextBinding | Binding de audience/tenant. |
+| `app.scope` | RequireScope | Legacy scopes/capabilities. |
+| `app.requires` | RequireAbility | OR lógico. |
+| `app.requires.all` | RequireAllAbilities | AND lógico. |
+| `app.throttle` | RateLimitByContext | Rate limiting por contexto. |
+| `app.audit` | InjectAuditContext | Inyección de contexto en logs. |
+
+## Middleware group `app-context`
+Orden recomendado:
+1) ResolveAppContext
+2) RateLimitByContext
+3) AuthenticateChannel
+4) EnforceContextBinding
+5) InjectAuditContext
+
+## Nota sobre RequireAllScopes
+Existe la clase `RequireAllScopes`, pero no está registrada como alias en el provider. Si la necesitas, debes registrarla manualmente en tu app.
+
+## Evidence
+- File: src/AppContextServiceProvider.php
+  - Symbol: AppContextServiceProvider::registerMiddleware()
+  - Notes: aliases y group `app-context`.
+- File: src/Middleware/RequireAllScopes.php
+  - Symbol: RequireAllScopes
+  - Notes: clase existente no registrada por defecto.

--- a/documentation/ronu/laravel-app-context/docs/10-migration-guide.md
+++ b/documentation/ronu/laravel-app-context/docs/10-migration-guide.md
@@ -1,0 +1,24 @@
+# Migration Guide
+
+Este repositorio incluye un `docs/MIGRATION.md` con pasos detallados para migrar desde Auth nativo, Sanctum, Passport o JWT custom. Esta guía resume lo esencial y apunta al archivo oficial.
+
+## Pasos mínimos recomendados
+1) Instalar paquete y publicar config.
+2) Definir canales y `auth_mode` correctos.
+3) Ajustar middleware en rutas (`app-context`).
+4) Emitir JWT con `aud`, `scp`, `tid` según canal/tenant.
+5) Migrar repositorio de clients si pasas de `config` a `eloquent`.
+
+## Dónde ampliar
+Consulta `docs/MIGRATION.md` para pasos por tipo de migración.
+
+## Evidence
+- File: docs/MIGRATION.md
+  - Symbol: (archivo completo)
+  - Notes: guía detallada de migración incluida en el repo.
+- File: src/AppContextServiceProvider.php
+  - Symbol: AppContextServiceProvider::registerMiddleware()
+  - Notes: middleware group recomendado para rutas.
+- File: config/app-context.php
+  - Symbol: channels, client_repository
+  - Notes: configuración que suele ajustarse en migraciones.

--- a/documentation/ronu/laravel-app-context/docs/11-contributing.md
+++ b/documentation/ronu/laravel-app-context/docs/11-contributing.md
@@ -1,0 +1,16 @@
+# Contributing
+
+## Flujo recomendado
+1) Crea un branch con un nombre descriptivo.
+2) Implementa cambios con tests cuando apliquen.
+3) Ejecuta `composer test` antes de abrir PR.
+
+## Tests
+```bash
+composer test
+```
+
+## Evidence
+- File: composer.json
+  - Symbol: scripts.test
+  - Notes: comando oficial de tests.

--- a/documentation/ronu/laravel-app-context/docs/12-license.md
+++ b/documentation/ronu/laravel-app-context/docs/12-license.md
@@ -1,0 +1,10 @@
+# License
+
+Este proyecto está bajo licencia MIT. Puedes usar, modificar y distribuir el software con la condición de mantener el aviso de copyright y la licencia.
+
+Consulta el archivo `LICENSE` para el texto completo.
+
+## Evidence
+- File: LICENSE
+  - Symbol: MIT License
+  - Notes: licencia oficial del repositorio.


### PR DESCRIPTION
### Motivation
- Entregar una documentación modular, lista para producción, que sintetice la arquitectura, configuración, seguridad y uso del paquete `ronu/laravel-app-context` según la metodología requerida. 
- Evitar ambigüedades en integración (middleware order, channels, JWT/API Key flows, repositorios) y proveer ejemplos reales basados en el código existente. 
- Facilitar la adopción y migración (migración desde Sanctum/Passport/custom JWT) y ofrecer checklist de seguridad para despliegue. 

### Description
- Se añadió un set estructurado de documentación bajo `documentation/ronu/laravel-app-context/` con un `README.md` y 27 archivos modulados: instalación, configuración, arquitectura, features (uno por feature), seguridad, testing, troubleshooting, FAQ, referencia (config keys, env vars, middleware, exceptions, artisan commands), migration, contributing y license. (28 ficheros creados en total). 
- Documentos clave incluidos: `README.md`, `docs/01-installation.md`, `docs/02-configuration.md`, `docs/03-architecture.md`, `docs/04-features/*` (JWT, API Key, context resolution, binding, rate limiting, audit, contextual scopes, resources, etc.), `docs/05-security.md`, `docs/06-testing.md`, `docs/07-troubleshooting.md` y `docs/09-reference/*`. 
- La documentación se apoya en evidencia encontrada en el repositorio (ej.: `config/app-context.php`, `src/AppContextServiceProvider.php`, `src/Middleware/*`, `src/Auth/Verifiers/*`, `src/Repositories/*`, `tests/Unit/*`) y recoge recomendaciones prácticas (middleware order, secure defaults, env vars, migration tips). 
- No se modificó código de producción; todos los cambios son archivos Markdown en `documentation/ronu/laravel-app-context/` y se añadieron al repo en un único commit (`Add structured documentation set`).

### Testing
- Cambios solo de documentación: no se ejecutaron tests automáticos sobre código fuente porque no hubo cambios funcionales. 
- Nota de uso: el proyecto incluye test-suite (`composer test`) y casos unitarios en `tests/Unit/`; los pasos para ejecutar tests están documentados en `docs/06-testing.md`.
- Resultado de la verificación del PR: documentación generada y commiteada correctamente; integración de tests en CI no afectada por este PR (no aplicada).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69828bb199c8832cbd66b3b64d0acb25)