### PR TITLE
Harden superuser checks for cross-tenant query scopes

### DIFF
--- a/config/tenancy.php
+++ b/config/tenancy.php
@@ -132,4 +132,19 @@ return [
         'alert_violations' => env('TENANCY_ALERT_VIOLATIONS', true),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Authorization
+    |--------------------------------------------------------------------------
+    |
+    | Optional callback used to determine whether the authenticated user can
+    | execute cross-tenant queries (forTenant/withoutTenant).
+    |
+    | Signature: fn (mixed $user): bool
+    |
+    */
+    'authorization' => [
+        'superuser_resolver' => null,
+    ],
+
 ];

--- a/tests/Unit/TenantScopeAuthorizationTest.php
+++ b/tests/Unit/TenantScopeAuthorizationTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ronu\AppContext\Tests\Unit;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Auth;
+use Ronu\AppContext\Scopes\TenantScope;
+use Ronu\AppContext\Tests\TestCase;
+
+class TenantScopeAuthorizationTest extends TestCase
+{
+    public function test_it_denies_cross_tenant_access_when_user_has_no_superuser_flag(): void
+    {
+        Auth::shouldReceive('user')->once()->andReturn((object) ['id' => 15]);
+
+        $this->assertFalse($this->invokeHasSuperuserPrivileges(new TenantScope()));
+    }
+
+    public function test_it_allows_resolver_callback_for_custom_user_schema(): void
+    {
+        config()->set('tenancy.authorization.superuser_resolver', static fn (object $user): bool => $user->role === 'root');
+
+        Auth::shouldReceive('user')->once()->andReturn((object) ['id' => 10, 'role' => 'root']);
+
+        $this->assertTrue($this->invokeHasSuperuserPrivileges(new TenantScope()));
+    }
+
+    public function test_it_reads_superuser_flag_from_user_attributes(): void
+    {
+        $user = new class () extends Model {
+            protected $guarded = [];
+        };
+
+        $user->forceFill(['is_superuser' => 1]);
+
+        Auth::shouldReceive('user')->once()->andReturn($user);
+
+        $this->assertTrue($this->invokeHasSuperuserPrivileges(new TenantScope()));
+    }
+
+    private function invokeHasSuperuserPrivileges(TenantScope $scope): bool
+    {
+        $method = new \ReflectionMethod(TenantScope::class, 'hasSuperuserPrivileges');
+        $method->setAccessible(true);
+
+        return (bool) $method->invoke($scope);
+    }
+}


### PR DESCRIPTION
### Motivation
- Prevent fragile authorization checks for cross-tenant helpers that assumed a single `is_superuser` attribute and could fail on alternative user schemas.
- Allow projects to provide a custom resolver for determining superuser privileges to support diverse user models.

### Description
- Replaced direct `auth()->user()?->is_superuser` checks with a resilient `hasSuperuserPrivileges()` helper added to `TenantScope` and `TenantAware` to centralize authorization logic.
- Added support for a configurable callback `tenancy.authorization.superuser_resolver` to allow custom superuser determination logic.
- The helper checks, in order: configured resolver callback, `isSuperuser()` method, Eloquent `getAttribute('is_superuser')`, and finally an array fallback using `Arr::get`.
- Added unit tests `tests/Unit/TenantScopeAuthorizationTest.php` covering missing `is_superuser` field, custom resolver callback, and Eloquent attribute reads, and updated `config/tenancy.php` to include the `authorization` section.

### Testing
- `php -l src/Scopes/TenantScope.php` passed with no syntax errors.
- `php -l src/Traits/TenantAware.php` passed with no syntax errors.
- `php -l tests/Unit/TenantScopeAuthorizationTest.php` passed with no syntax errors.
- `composer install --no-interaction` failed due to network/proxy restrictions in the execution environment so `vendor/bin/phpunit` could not be run and unit tests were not executed; the tests were added and are ready to run once dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b70addba8832c99281db8d5aa92f8)